### PR TITLE
#51 [FEATURE] 학생이 캘린더로 메모 조회 클릭으로 메모 추가 기능 구현

### DIFF
--- a/src/main/java/com/wanted/projectmodule2lms/domain/calendar/controller/StudentCalendarController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/calendar/controller/StudentCalendarController.java
@@ -4,9 +4,8 @@ import com.wanted.projectmodule2lms.domain.calendar.model.dto.CalendarEventDTO;
 import com.wanted.projectmodule2lms.domain.calendar.model.service.CalenderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
+import com.wanted.projectmodule2lms.domain.calendar.model.dto.CalendarMemoCreateDTO;
 
 import java.util.List;
 
@@ -27,5 +26,19 @@ public class StudentCalendarController {
     public List<CalendarEventDTO> getCalendarEvents() {
         Integer memberId = 1; // 임시 로그인 사용자
         return calendarService.findStudentCalendarEvents(memberId);
+    }
+    @GetMapping("/memos")
+    @ResponseBody
+    public List<?> getMemosByDate(@RequestParam String date) {
+        Integer memberId = 1; // 임시 로그인 사용자
+        return calendarService.findMemosByDate(memberId, date);
+    }
+
+    @PostMapping
+    @ResponseBody
+    public String createMemo(@ModelAttribute CalendarMemoCreateDTO dto) {
+        Integer memberId = 1; // 임시 로그인 사용자
+        calendarService.createMemo(memberId, dto);
+        return "ok";
     }
 }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/dao/CalendarMemoRepository.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/dao/CalendarMemoRepository.java
@@ -1,0 +1,14 @@
+package com.wanted.projectmodule2lms.domain.calendar.model.dao;
+
+import com.wanted.projectmodule2lms.domain.calendar.model.entity.CalendarMemo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface CalendarMemoRepository extends JpaRepository<CalendarMemo, Integer> {
+
+    List<CalendarMemo> findByMemberId(Integer memberId);
+
+    List<CalendarMemo> findByMemberIdAndMemoDate(Integer memberId, LocalDate memoDate);
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/dto/CalendarMemoCreateDTO.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/dto/CalendarMemoCreateDTO.java
@@ -1,0 +1,12 @@
+package com.wanted.projectmodule2lms.domain.calendar.model.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CalendarMemoCreateDTO {
+
+    private String content;
+    private String memoDate;
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/dto/CalendarMemoDTO.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/dto/CalendarMemoDTO.java
@@ -1,0 +1,13 @@
+package com.wanted.projectmodule2lms.domain.calendar.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CalendarMemoDTO {
+
+    private Integer memoId;
+    private String content;
+    private String memoDate;
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/entity/CalendarMemo.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/entity/CalendarMemo.java
@@ -1,0 +1,39 @@
+package com.wanted.projectmodule2lms.domain.calendar.model.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "Memo")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CalendarMemo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memo_id")
+    private Integer memoId;
+
+    @Column(name = "member_id", nullable = false)
+    private Integer memberId;
+
+    @Column(name = "content", nullable = false, length = 255)
+    private String content;
+
+    @Column(name = "memo_date", nullable = false)
+    private LocalDate memoDate;
+
+    public CalendarMemo(Integer memberId, String content, LocalDate memoDate) {
+        this.memberId = memberId;
+        this.content = content;
+        this.memoDate = memoDate;
+    }
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/service/CalenderService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/service/CalenderService.java
@@ -1,6 +1,10 @@
 package com.wanted.projectmodule2lms.domain.calendar.model.service;
 
+import com.wanted.projectmodule2lms.domain.calendar.model.dao.CalendarMemoRepository;
 import com.wanted.projectmodule2lms.domain.calendar.model.dto.CalendarEventDTO;
+import com.wanted.projectmodule2lms.domain.calendar.model.dto.CalendarMemoCreateDTO;
+import com.wanted.projectmodule2lms.domain.calendar.model.dto.CalendarMemoDTO;
+import com.wanted.projectmodule2lms.domain.calendar.model.entity.CalendarMemo;
 import com.wanted.projectmodule2lms.domain.course.model.dao.CourseRepository;
 import com.wanted.projectmodule2lms.domain.course.model.entity.Course;
 import com.wanted.projectmodule2lms.domain.enrollment.model.dao.EnrollmentRepository;
@@ -10,6 +14,7 @@ import com.wanted.projectmodule2lms.domain.section.model.entity.Section;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -17,44 +22,60 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class CalenderService {
-
+    private final CalendarMemoRepository calendarMemoRepository;
     private final CourseRepository courseRepository;
     private final EnrollmentRepository enrollmentRepository;
     private final SectionRepository sectionRepository;
 
     public List<CalendarEventDTO> findStudentCalendarEvents(Integer memberId) {
 
+        List<CalendarEventDTO> result = new java.util.ArrayList<>();
+
         List<Integer> courseIds = enrollmentRepository.findByMemberId(memberId)
                 .stream()
                 .map(Enrollment::getCourseId)
                 .toList();
 
-        if (courseIds.isEmpty()) {
-            return List.of();
+        if (!courseIds.isEmpty()) {
+            List<Course> courses = courseRepository.findByCourseIdIn(courseIds);
+
+            Map<Integer, String> courseTitleMap = courses.stream()
+                    .collect(Collectors.toMap(
+                            Course::getCourseId,
+                            Course::getTitle
+                    ));
+
+            List<Section> sections = sectionRepository.findByCourseIdIn(courseIds);
+
+            List<CalendarEventDTO> sectionEvents = sections.stream()
+                    .filter(section -> section.getOpenDate() != null)
+                    .map(section -> {
+                        String courseTitle = courseTitleMap.getOrDefault(section.getCourseId(), "강의");
+                        return new CalendarEventDTO(
+                                "section-" + section.getSectionId(),
+                                courseTitle + " - " + section.getTitle(),
+                                section.getOpenDate().toString(),
+                                "#3b82f6"
+                        );
+                    })
+                    .collect(Collectors.toList());
+
+            result.addAll(sectionEvents);
         }
 
-        List<Course> courses = courseRepository.findByCourseIdIn(courseIds);
-
-        Map<Integer, String> courseTitleMap = courses.stream()
-                .collect(Collectors.toMap(
-                        Course::getCourseId,
-                        Course::getTitle
-                ));
-
-        List<Section> sections = sectionRepository.findByCourseIdIn(courseIds);
-
-        return sections.stream()
-                .filter(section -> section.getOpenDate() != null)
-                .map(section -> {
-                    String courseTitle = courseTitleMap.getOrDefault(section.getCourseId(), "강의");
-                    return new CalendarEventDTO(
-                            "section-" + section.getSectionId(),
-                            courseTitle + " - " + section.getTitle(),
-                            section.getOpenDate().toString(),
-                            "#3b82f6"
-                    );
-                })
+        List<CalendarEventDTO> memoEvents = calendarMemoRepository.findByMemberId(memberId)
+                .stream()
+                .map(memo -> new CalendarEventDTO(
+                        "memo-" + memo.getMemoId(),
+                        "[메모] " + memo.getContent(),
+                        memo.getMemoDate().toString(),
+                        "#f59e0b"
+                ))
                 .collect(Collectors.toList());
+
+        result.addAll(memoEvents);
+
+        return result;
     }
 
     public List<CalendarEventDTO> findInstructorCalendarEvents(Integer instructorId) {
@@ -89,5 +110,26 @@ public class CalenderService {
                     );
                 })
                 .collect(Collectors.toList());
+    }
+
+    public List<CalendarMemoDTO> findMemosByDate(Integer memberId, String date) {
+        return calendarMemoRepository.findByMemberIdAndMemoDate(memberId, LocalDate.parse(date))
+                .stream()
+                .map(memo -> new CalendarMemoDTO(
+                        memo.getMemoId(),
+                        memo.getContent(),
+                        memo.getMemoDate().toString()
+                ))
+                .toList();
+    }
+
+    public void createMemo(Integer memberId, CalendarMemoCreateDTO dto) {
+        CalendarMemo memo = new CalendarMemo(
+                memberId,
+                dto.getContent(),
+                LocalDate.parse(dto.getMemoDate())
+        );
+
+        calendarMemoRepository.save(memo);
     }
 }

--- a/src/main/resources/templates/student/calendar/view.html
+++ b/src/main/resources/templates/student/calendar/view.html
@@ -6,24 +6,190 @@
 
     <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.js"></script>
+    <style>
+        .calendar-layout {
+            display: flex;
+            gap: 20px;
+            align-items: flex-start;
+        }
+
+        .calendar-area {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .side-panel {
+            flex: 0 0 320px;
+            min-width: 320px;
+            border-left: 1px solid #ddd;
+            padding-left: 20px;
+            background-color: #fff8dc;
+        }
+        .panel-box {
+            margin-bottom: 20px;
+        }
+
+        .panel-item {
+            margin-bottom: 8px;
+            padding: 10px;
+            background: #f5f5f5;
+            border-radius: 6px;
+            word-break: break-word;
+        }
+
+        textarea {
+            width: 100%;
+            min-height: 100px;
+            resize: vertical;
+        }
+
+        button {
+            margin-top: 10px;
+            padding: 8px 14px;
+        }
+    </style>
 </head>
 <body>
 <h2>📅 나의 학습 캘린더</h2>
-<div id="calendar"></div>
+
+<div class="calendar-layout">
+    <div class="calendar-area">
+        <div id="calendar"></div>
+    </div>
+
+    <div class="side-panel">
+        <h3 id="selectedDate">날짜를 선택하세요</h3>
+
+        <div class="panel-box">
+            <h4>그날 일정</h4>
+            <div id="scheduleList">날짜를 클릭하면 일정이 표시됩니다.</div>
+        </div>
+
+        <div class="panel-box">
+            <h4>메모</h4>
+            <div id="memoList">날짜를 클릭하면 메모가 표시됩니다.</div>
+        </div>
+
+        <div class="panel-box">
+            <h4>메모 추가</h4>
+            <textarea id="memoContent" placeholder="메모를 입력하세요"></textarea>
+            <button type="button" id="saveMemoBtn">추가</button>
+        </div>
+    </div>
+</div>
 
 <script>
+    let allEvents = [];
+    let selectedDate = null;
+    let calendar = null;
+
     document.addEventListener('DOMContentLoaded', function () {
         const calendarEl = document.getElementById('calendar');
 
-        const calendar = new FullCalendar.Calendar(calendarEl, {
-            initialView: 'dayGridMonth',
-            locale: 'ko',
-            height: 700,
-            events: '/student/calendar/events'
-        });
+        fetch('/student/calendar/events')
+            .then(response => response.json())
+            .then(data => {
+                allEvents = data;
 
-        calendar.render();
+                calendar = new FullCalendar.Calendar(calendarEl, {
+                    initialView: 'dayGridMonth',
+                    locale: 'ko',
+                    height: 700,
+                    events: allEvents,
+
+                    dateClick: function(info) {
+                        selectedDate = info.dateStr;
+                        document.getElementById('selectedDate').innerText = selectedDate;
+
+                        renderDayEvents(selectedDate);
+                        loadMemos(selectedDate);
+                    }
+                });
+
+                calendar.render();
+            });
+
+        document.getElementById('saveMemoBtn').addEventListener('click', function () {
+            saveMemo();
+        });
     });
+
+    function renderDayEvents(date) {
+        const scheduleList = document.getElementById('scheduleList');
+        scheduleList.innerHTML = '';
+
+        const dayEvents = allEvents.filter(event => event.start === date);
+
+        if (dayEvents.length === 0) {
+            scheduleList.innerHTML = '<div class="panel-item">일정 없음</div>';
+            return;
+        }
+
+        dayEvents.forEach(event => {
+            scheduleList.innerHTML += `<div class="panel-item">${event.title}</div>`;
+        });
+    }
+
+    function loadMemos(date) {
+        fetch('/student/calendar/memos?date=' + date)
+            .then(response => response.json())
+            .then(data => {
+                const memoList = document.getElementById('memoList');
+                memoList.innerHTML = '';
+
+                if (data.length === 0) {
+                    memoList.innerHTML = '<div class="panel-item">메모 없음</div>';
+                    return;
+                }
+
+                data.forEach(memo => {
+                    memoList.innerHTML += `<div class="panel-item">${memo.content}</div>`;
+                });
+            });
+    }
+
+    function saveMemo() {
+        const content = document.getElementById('memoContent').value.trim();
+
+        if (!selectedDate) {
+            alert('먼저 날짜를 선택하세요.');
+            return;
+        }
+
+        if (!content) {
+            alert('메모 내용을 입력하세요.');
+            return;
+        }
+
+        const formData = new URLSearchParams();
+        formData.append('content', content);
+        formData.append('memoDate', selectedDate);
+
+        fetch('/student/calendar', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: formData
+        })
+            .then(response => response.text())
+            .then(() => {
+                document.getElementById('memoContent').value = '';
+
+                const newMemoEvent = {
+                    id: 'memo-temp-' + Date.now(),
+                    title: '[메모] ' + content,
+                    start: selectedDate,
+                    color: '#f59e0b'
+                };
+
+                allEvents.push(newMemoEvent);
+                calendar.addEvent(newMemoEvent);
+
+                renderDayEvents(selectedDate);
+                loadMemos(selectedDate);
+            });
+    }
 </script>
 </body>
 </html>


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당하는 항목에 체크하세요 -->
- [x] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 🔗 관련 이슈
Closes #51 

---

## 🛠️ 작업 내용
- 학생이 캘린더로 메모 조회, 날짜 클릭으로 일정까지 조회하고 메모 추가 기능 구현
- 
- 

---

## 🔄 변경 사항
- calendar도메인에 메모 서비스,엔티티,컨트롤러 추가로 기능 구현 
- 
- 

---

## ✅ 체크리스트
- [x] 팀 코딩 컨벤션을 준수했습니다.
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 불필요한 코드는 제거했습니다.
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우).