### PR TITLE
[FEATURE] 게시판 댓글/대댓글 및 권한 처리 기능 구현

### DIFF
--- a/src/main/java/com/wanted/projectmodule2lms/domain/board/controller/BoardController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/board/controller/BoardController.java
@@ -3,6 +3,8 @@ package com.wanted.projectmodule2lms.domain.board.controller;
 import com.wanted.projectmodule2lms.domain.board.model.dto.BoardDTO;
 import com.wanted.projectmodule2lms.domain.board.model.entity.BoardType;
 import com.wanted.projectmodule2lms.domain.board.model.service.BoardService;
+import com.wanted.projectmodule2lms.domain.comment.model.dto.CommentDTO;
+import com.wanted.projectmodule2lms.domain.comment.model.service.CommentService;
 import com.wanted.projectmodule2lms.domain.course.model.entity.Course;
 import com.wanted.projectmodule2lms.domain.member.model.entity.MemberRole;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import java.util.List;
 @RequestMapping("/board")
 public class BoardController {
 
+    private final CommentService commentService;
     private final BoardService boardService;
 
     @GetMapping({"", "/"})
@@ -83,7 +86,9 @@ public class BoardController {
     public String boardDetailPage(@RequestParam Integer postId, Model model) {
         boardService.increaseViewCount(postId);
         BoardDTO board = boardService.findBoardById(postId);
+        List<CommentDTO> commentList=commentService.findCommentsByPostId(postId);
         model.addAttribute("board", board);
+        model.addAttribute("commentList", commentList);
         model.addAttribute("listPath", getListPath(board.getPostType()));
         return "board/detail";
     }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/board/model/dto/BoardDTO.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/board/model/dto/BoardDTO.java
@@ -22,6 +22,7 @@ public class BoardDTO {
     private String memberName;
     private Integer courseId;
     private String courseTitle;
+    private Integer courseInstructorId;
     private Integer sectionId;
     private String sectionTitle;
     private String title;

--- a/src/main/java/com/wanted/projectmodule2lms/domain/board/model/service/BoardService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/board/model/service/BoardService.java
@@ -360,6 +360,7 @@ public class BoardService {
                 board,
                 loadMemberNameMap(Collections.singletonList(board)),
                 loadCourseTitleMap(Collections.singletonList(board)),
+                loadCourseInstructorMap(Collections.singletonList(board)),
                 loadSectionTitleMap(Collections.singletonList(board))
         );
     }
@@ -367,22 +368,25 @@ public class BoardService {
     private List<BoardDTO> toBoardDTOList(List<Board> boards) {
         Map<Integer, String> memberNameMap = loadMemberNameMap(boards);
         Map<Integer, String> courseTitleMap = loadCourseTitleMap(boards);
+        Map<Integer, Integer> courseInstructorMap = loadCourseInstructorMap(boards);
         Map<Integer, String> sectionTitleMap = loadSectionTitleMap(boards);
 
         return boards.stream()
-                .map(board -> toBoardDTO(board, memberNameMap, courseTitleMap, sectionTitleMap))
+                .map(board -> toBoardDTO(board, memberNameMap, courseTitleMap, courseInstructorMap, sectionTitleMap))
                 .collect(Collectors.toList());
     }
 
     private BoardDTO toBoardDTO(Board board,
                                 Map<Integer, String> memberNameMap,
                                 Map<Integer, String> courseTitleMap,
+                                Map<Integer, Integer> courseInstructorMap,
                                 Map<Integer, String> sectionTitleMap) {
         BoardDTO boardDTO = modelMapper.map(board, BoardDTO.class);
         boardDTO.setMemberName(resolveMemberName(board.getMemberId(), memberNameMap));
 
         if (board.getCourseId() != null) {
             boardDTO.setCourseTitle(resolveCourseTitle(board.getCourseId(), courseTitleMap));
+            boardDTO.setCourseInstructorId(resolveCourseInstructorId(board.getCourseId(), courseInstructorMap));
         }
 
         if (board.getSectionId() != null) {
@@ -419,6 +423,20 @@ public class BoardService {
                 .collect(Collectors.toMap(Course::getCourseId, Course::getTitle));
     }
 
+    private Map<Integer, Integer> loadCourseInstructorMap(List<Board> boards) {
+        Set<Integer> courseIds = boards.stream()
+                .map(Board::getCourseId)
+                .filter(courseId -> courseId != null)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        if (courseIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        return courseRepository.findAllById(courseIds).stream()
+                .collect(Collectors.toMap(Course::getCourseId, Course::getInstructorId));
+    }
+
     private Map<Integer, String> loadSectionTitleMap(List<Board> boards) {
         Set<Integer> sectionIds = boards.stream()
                 .map(Board::getSectionId)
@@ -453,6 +471,15 @@ public class BoardService {
         }
 
         return courseTitle;
+    }
+
+    private Integer resolveCourseInstructorId(Integer courseId, Map<Integer, Integer> courseInstructorMap) {
+        Integer courseInstructorId = courseInstructorMap.get(courseId);
+        if (courseInstructorId == null) {
+            throw new IllegalStateException("게시글 코스 담당 강사 정보를 찾을 수 없습니다. courseId=" + courseId);
+        }
+
+        return courseInstructorId;
     }
 
     private String resolveSectionTitle(Integer sectionId, Map<Integer, String> sectionTitleMap) {

--- a/src/main/java/com/wanted/projectmodule2lms/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/comment/controller/CommentController.java
@@ -1,0 +1,63 @@
+package com.wanted.projectmodule2lms.domain.comment.controller;
+
+import com.wanted.projectmodule2lms.domain.comment.model.dto.CommentDTO;
+import com.wanted.projectmodule2lms.domain.comment.model.service.CommentService;
+import com.wanted.projectmodule2lms.domain.member.model.entity.MemberRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/regist")
+    public String registerComment(@ModelAttribute CommentDTO commentDTO,
+                                  @RequestParam Integer currentMemberId,
+                                  @RequestParam MemberRole currentRole,
+                                  RedirectAttributes redirectAttributes) {
+        try {
+            commentService.registComment(commentDTO, currentMemberId, currentRole);
+            return "redirect:/board/detail?postId=" + commentDTO.getPostId();
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return "redirect:/board/detail?postId=" + commentDTO.getPostId();
+        }
+    }
+
+    @PostMapping("/modify")
+    public String modifyComment(@ModelAttribute CommentDTO commentDTO,
+                                @RequestParam Integer currentMemberId,
+                                @RequestParam MemberRole currentRole,
+                                RedirectAttributes redirectAttributes) {
+        try {
+            commentService.modifyComment(commentDTO, currentMemberId, currentRole);
+            return "redirect:/board/detail?postId=" + commentDTO.getPostId();
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return "redirect:/board/detail?postId=" + commentDTO.getPostId();
+        }
+    }
+
+    @PostMapping("/delete")
+    public String deleteComment(@RequestParam Integer commentId,
+                                @RequestParam Integer postId,
+                                @RequestParam Integer currentMemberId,
+                                @RequestParam MemberRole currentRole,
+                                RedirectAttributes redirectAttributes) {
+        try {
+            commentService.deleteComment(commentId, postId, currentMemberId, currentRole);
+            return "redirect:/board/detail?postId=" + postId;
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return "redirect:/board/detail?postId=" + postId;
+        }
+    }
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/dao/CommentRepository.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/dao/CommentRepository.java
@@ -1,0 +1,16 @@
+package com.wanted.projectmodule2lms.domain.comment.model.dao;
+
+
+import com.wanted.projectmodule2lms.domain.comment.model.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Integer> {
+
+    List<Comment> findByPostIdAndIsDeletedFalse(Integer postId);
+
+    List<Comment> findByPostIdAndIsDeletedFalseOrderByCommentIdAsc(Integer postId);
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/dto/CommentDTO.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/dto/CommentDTO.java
@@ -1,0 +1,23 @@
+package com.wanted.projectmodule2lms.domain.comment.model.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class CommentDTO {
+
+    private Integer commentId;
+    private Integer postId;
+    private Integer memberId;
+    private Integer parentCommentId;
+    private String content;
+    private Boolean isDeleted;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String memberName;
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/entity/Comment.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/entity/Comment.java
@@ -1,0 +1,58 @@
+package com.wanted.projectmodule2lms.domain.comment.model.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "Comment")
+@Getter
+@NoArgsConstructor
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Integer commentId;
+
+    @Column(name = "post_id", nullable = false)
+    private Integer postId;
+
+    @Column(name = "member_id", nullable = false)
+    private Integer memberId;
+
+    @Column(name = "parent_comment_id")
+    private Integer parentCommentId;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted;
+
+    @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false, insertable = false, updatable = false)
+    private LocalDateTime updatedAt;
+
+    public Comment(Integer postId, Integer memberId, Integer parentCommentId, String content) {
+        this.postId = postId;
+        this.memberId = memberId;
+        this.parentCommentId = parentCommentId;
+        this.content = content;
+        this.isDeleted = false;
+    }
+    public void changeContent(String content) {
+
+
+        this.content = content;
+    }
+    public void deleteComment() {
+        this.isDeleted = true;
+    }
+
+
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/service/CommentService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/service/CommentService.java
@@ -1,0 +1,163 @@
+package com.wanted.projectmodule2lms.domain.comment.model.service;
+
+import com.wanted.projectmodule2lms.domain.board.model.dto.BoardDTO;
+import com.wanted.projectmodule2lms.domain.board.model.entity.BoardType;
+import com.wanted.projectmodule2lms.domain.board.model.service.BoardService;
+import com.wanted.projectmodule2lms.domain.comment.model.dao.CommentRepository;
+import com.wanted.projectmodule2lms.domain.comment.model.dto.CommentDTO;
+import com.wanted.projectmodule2lms.domain.comment.model.entity.Comment;
+import com.wanted.projectmodule2lms.domain.course.model.dao.CourseRepository;
+import com.wanted.projectmodule2lms.domain.enrollment.model.dao.EnrollmentRepository;
+import com.wanted.projectmodule2lms.domain.enrollment.model.entity.Enrollment;
+import com.wanted.projectmodule2lms.domain.member.model.dao.MemberRepository;
+import com.wanted.projectmodule2lms.domain.member.model.entity.Member;
+import com.wanted.projectmodule2lms.domain.member.model.entity.MemberRole;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final ModelMapper modelMapper;
+    private final MemberRepository memberRepository;
+    private final BoardService boardService;
+    private final CourseRepository courseRepository;
+    private final EnrollmentRepository enrollmentRepository;
+
+    public List<CommentDTO> findCommentsByPostId(Integer postId) {
+        List<Comment> commentList = commentRepository.findByPostIdAndIsDeletedFalseOrderByCommentIdAsc(postId);
+
+        return commentList.stream()
+                .map(comment -> {
+                    String memberName = memberRepository.findById(comment.getMemberId())
+                            .map(Member::getName)
+                            .orElse(null);
+
+                    return new CommentDTO(
+                            comment.getCommentId(),
+                            comment.getPostId(),
+                            comment.getMemberId(),
+                            comment.getParentCommentId(),
+                            comment.getContent(),
+                            comment.getIsDeleted(),
+                            comment.getCreatedAt(),
+                            comment.getUpdatedAt(),
+                            memberName
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void registComment(CommentDTO commentDTO, Integer currentMemberId, MemberRole currentRole) {
+        BoardDTO board = boardService.findBoardById(commentDTO.getPostId());
+
+        if (!canCreateComment(currentMemberId, currentRole, board)) {
+            throw new IllegalArgumentException("댓글 작성 권한이 없습니다.");
+        }
+
+        Comment comment = new Comment(
+                commentDTO.getPostId(),
+                currentMemberId,
+                commentDTO.getParentCommentId(),
+                commentDTO.getContent()
+        );
+        commentRepository.save(comment);
+    }
+
+    @Transactional
+    public void modifyComment(CommentDTO commentDTO, Integer currentMemberId, MemberRole currentRole) {
+        Comment comment = commentRepository.findById(commentDTO.getCommentId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 존재하지 않습니다."));
+        BoardDTO board = boardService.findBoardById(comment.getPostId());
+
+        if (!canModifyOrDeleteComment(currentMemberId, currentRole, comment, board)) {
+            throw new IllegalArgumentException("댓글 수정 권한이 없습니다.");
+        }
+
+        comment.changeContent(commentDTO.getContent());
+    }
+
+    @Transactional
+    public void deleteComment(Integer commentId, Integer postId, Integer currentMemberId, MemberRole currentRole) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 댓글이 존재하지 않습니다."));
+        BoardDTO board = boardService.findBoardById(comment.getPostId());
+
+        if (!canModifyOrDeleteComment(currentMemberId, currentRole, comment, board)) {
+            throw new IllegalArgumentException("댓글 삭제 권한이 없습니다.");
+        }
+
+        comment.deleteComment();
+    }
+
+    private boolean canCreateComment(Integer currentMemberId, MemberRole currentRole, BoardDTO board) {
+        if (board.getPostType() != BoardType.SECTION_QNA) {
+            return true;
+        }
+
+        if (currentRole == MemberRole.ADMIN) {
+            return true;
+        }
+
+        if (board.getCourseId() == null) {
+            return false;
+        }
+
+        if (currentRole == MemberRole.INSTRUCTOR) {
+            return isInstructorCourse(board.getCourseId(), currentMemberId);
+        }
+
+        if (currentRole == MemberRole.STUDENT) {
+            return isEnrolledCourse(board.getCourseId(), currentMemberId);
+        }
+
+        return false;
+    }
+
+    private boolean canModifyOrDeleteComment(Integer currentMemberId,
+                                             MemberRole currentRole,
+                                             Comment comment,
+                                             BoardDTO board) {
+        if (currentRole == MemberRole.ADMIN) {
+            return true;
+        }
+
+        if (currentMemberId.equals(comment.getMemberId())) {
+            if (board.getPostType() != BoardType.SECTION_QNA) {
+                return true;
+            }
+
+            return board.getCourseId() != null && isEnrolledCourse(board.getCourseId(), currentMemberId);
+        }
+
+        if (board.getPostType() == BoardType.COURSE_NOTICE && currentRole == MemberRole.INSTRUCTOR) {
+            return board.getCourseId() != null && isInstructorCourse(board.getCourseId(), currentMemberId);
+        }
+
+        if (board.getPostType() == BoardType.SECTION_QNA && currentRole == MemberRole.INSTRUCTOR) {
+            return board.getCourseId() != null && isInstructorCourse(board.getCourseId(), currentMemberId);
+        }
+
+        return false;
+    }
+
+    private boolean isInstructorCourse(Integer courseId, Integer currentMemberId) {
+        return courseRepository.findById(courseId)
+                .map(course -> course.getInstructorId().equals(currentMemberId))
+                .orElse(false);
+    }
+
+    private boolean isEnrolledCourse(Integer courseId, Integer currentMemberId) {
+        return enrollmentRepository.findByMemberId(currentMemberId).stream()
+                .map(Enrollment::getCourseId)
+                .anyMatch(courseId::equals);
+    }
+}

--- a/src/main/resources/static/css/board/crud.css
+++ b/src/main/resources/static/css/board/crud.css
@@ -258,15 +258,31 @@ body {
 }
 
 .blurred-secret {
-    filter: blur(6px);
+    filter: blur(8px);
     user-select: none;
+    color: transparent !important;
+    text-shadow: 0 0 10px rgba(34, 34, 34, 0.75);
+    transition: filter 0.15s ease;
 }
 
 .secret-blocked {
     pointer-events: auto;
 }
 
+.secret-blocked::after {
+    content: "비밀글";
+    margin-left: 8px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: #111827;
+    color: #fff;
+    font-size: 12px;
+    font-weight: 700;
+    vertical-align: middle;
+}
+
 [data-role-only].is-hidden,
-[data-board-action].is-hidden {
+[data-board-action].is-hidden,
+[data-comment-action].is-hidden {
     display: none !important;
 }

--- a/src/main/resources/static/js/board/role-switcher.js
+++ b/src/main/resources/static/js/board/role-switcher.js
@@ -65,6 +65,26 @@
         return currentMemberId === authorId;
     }
 
+    function canManageComment(role, currentMemberId, postType, authorId, courseInstructorId) {
+        if (!postType || !authorId) {
+            return false;
+        }
+
+        if (role === "ADMIN") {
+            return true;
+        }
+
+        if (currentMemberId === authorId) {
+            return true;
+        }
+
+        if (role === "INSTRUCTOR" && (postType === "COURSE_NOTICE" || postType === "SECTION_QNA")) {
+            return !!courseInstructorId && currentMemberId === courseInstructorId;
+        }
+
+        return false;
+    }
+
     function applyRole(role) {
         const currentMemberId = getCurrentMemberId(role);
 
@@ -115,6 +135,14 @@
             const visible = canReadSecret(role, currentMemberId, postType, authorId, isSecret);
             element.classList.toggle("blurred-secret", !visible);
             element.classList.toggle("secret-blocked", !visible);
+        });
+
+        document.querySelectorAll("[data-comment-action]").forEach(element => {
+            const postType = element.dataset.postType;
+            const authorId = element.dataset.authorId;
+            const courseInstructorId = element.dataset.courseInstructorId;
+            const visible = canManageComment(role, currentMemberId, postType, authorId, courseInstructorId);
+            element.classList.toggle("is-hidden", !visible);
         });
 
         document.querySelectorAll(".role-btn").forEach(button => {

--- a/src/main/resources/templates/board/delete.html
+++ b/src/main/resources/templates/board/delete.html
@@ -51,7 +51,9 @@
             </table>
 
             <div class="button-group">
-                <button type="submit" class="btn red">삭제</button>
+                <button type="submit"
+                        class="btn red"
+                        onclick="return confirm('정말 삭제하시겠습니까?');">삭제</button>
                 <a class="btn gray" th:href="@{/board/detail(postId=${board.postId})}">취소</a>
             </div>
         </form>

--- a/src/main/resources/templates/board/detail.html
+++ b/src/main/resources/templates/board/detail.html
@@ -62,6 +62,124 @@
             <a class="btn gray" th:href="${listPath}">목록으로</a>
         </div>
     </div>
+    <div class="box">
+        <h2>댓글</h2>
+
+        <table class="table">
+            <thead>
+            <tr>
+                <th>작성자</th>
+                <th>내용</th>
+                <th>작성일</th>
+                <th>관리</th>
+            </tr>
+            </thead>
+            <tbody>
+            <th:block th:each="comment : ${commentList}" th:if="${comment.parentCommentId == null}">
+                <tr>
+                    <td th:text="${comment.memberName != null ? comment.memberName : comment.memberId}">김학생</td>
+                    <td th:text="${comment.content}">댓글 내용</td>
+                    <td th:text="${comment.createdAt}">2026-04-15</td>
+                    <td>
+                        <form method="post"
+                              action="/comment/modify"
+                              data-comment-action="manage"
+                              th:attr="data-post-type=${board.postType},
+                                       data-author-id=${comment.memberId},
+                                       data-course-instructor-id=${board.courseInstructorId}">
+                            <input type="hidden" name="commentId" th:value="${comment.commentId}">
+                            <input type="hidden" name="postId" th:value="${board.postId}">
+                            <input type="hidden" name="currentMemberId" data-current-member-id-input>
+                            <input type="hidden" name="currentRole" data-current-role-input>
+                            <textarea name="content" th:text="${comment.content}" required></textarea>
+                            <div class="button-group">
+                                <button type="submit" class="btn">댓글 수정</button>
+                                <button type="submit"
+                                        class="btn red"
+                                        formaction="/comment/delete"
+                                        formmethod="post"
+                                        onclick="return confirm('정말 삭제하시겠습니까?');">댓글 삭제</button>
+                            </div>
+                        </form>
+                    </td>
+                </tr>
+
+                <tr th:each="reply : ${commentList}" th:if="${reply.parentCommentId == comment.commentId}">
+                    <td th:text="${'ㄴ ' + (reply.memberName != null ? reply.memberName : reply.memberId)}">ㄴ 박강사</td>
+                    <td th:text="${reply.content}">대댓글 내용</td>
+                    <td th:text="${reply.createdAt}">2026-04-15</td>
+                    <td>
+                        <form method="post"
+                              action="/comment/modify"
+                              data-comment-action="manage"
+                              th:attr="data-post-type=${board.postType},
+                                       data-author-id=${reply.memberId},
+                                       data-course-instructor-id=${board.courseInstructorId}">
+                            <input type="hidden" name="commentId" th:value="${reply.commentId}">
+                            <input type="hidden" name="postId" th:value="${board.postId}">
+                            <input type="hidden" name="currentMemberId" data-current-member-id-input>
+                            <input type="hidden" name="currentRole" data-current-role-input>
+                            <textarea name="content" th:text="${reply.content}" required></textarea>
+                            <div class="button-group">
+                                <button type="submit" class="btn">댓글 수정</button>
+                                <button type="submit"
+                                        class="btn red"
+                                        formaction="/comment/delete"
+                                        formmethod="post"
+                                        onclick="return confirm('정말 삭제하시겠습니까?');">댓글 삭제</button>
+                            </div>
+                        </form>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td colspan="4">
+                        <form method="post" action="/comment/regist">
+                            <input type="hidden" name="postId" th:value="${board.postId}">
+                            <input type="hidden" name="memberId" data-current-member-id-input>
+                            <input type="hidden" name="currentMemberId" data-current-member-id-input>
+                            <input type="hidden" name="currentRole" data-current-role-input>
+                            <input type="hidden" name="parentCommentId" th:value="${comment.commentId}">
+
+                            <div class="form-row">
+                                <label th:for="${'replyContent-' + comment.commentId}">답글 작성</label>
+                                <textarea th:id="${'replyContent-' + comment.commentId}" name="content" required></textarea>
+                            </div>
+
+                            <div class="button-group">
+                                <button type="submit" class="btn gray">답글 등록</button>
+                            </div>
+                        </form>
+                    </td>
+                </tr>
+            </th:block>
+            <tr th:if="${commentList == null or #lists.isEmpty(commentList)}">
+                <td colspan="4">등록된 댓글이 없습니다.</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="box">
+        <h2>댓글 작성</h2>
+
+        <form method="post" action="/comment/regist">
+            <input type="hidden" name="postId" th:value="${board.postId}">
+            <input type="hidden" name="memberId" data-current-member-id-input>
+            <input type="hidden" name="currentMemberId" data-current-member-id-input>
+            <input type="hidden" name="currentRole" data-current-role-input>
+            <input type="hidden" name="parentCommentId" value="">
+
+            <div class="form-row">
+                <label for="commentContent">내용</label>
+                <textarea id="commentContent" name="content" required></textarea>
+            </div>
+
+            <div class="button-group">
+                <button type="submit" class="btn">댓글 등록</button>
+            </div>
+        </form>
+    </div>
 </div>
 <script src="/js/board/role-switcher.js"></script>
 <script th:if="${errorMessage != null}" th:inline="javascript">

--- a/src/main/resources/templates/main/main.html
+++ b/src/main/resources/templates/main/main.html
@@ -114,13 +114,13 @@
                 <p class="text-on-surface-variant text-sm">엄선된 프리미엄 학술 과정을 탐색하세요.</p>
             </div>
             <!-- Communication -->
-            <div class="bg-surface-container-lowest p-8 rounded-xl shadow-sm hover:shadow-md transition-all group cursor-pointer border-l-4 border-secondary">
+            <a class="block bg-surface-container-lowest p-8 rounded-xl shadow-sm hover:shadow-md transition-all group cursor-pointer border-l-4 border-secondary" href="/board/list">
                 <div class="w-12 h-12 bg-secondary-container/20 rounded-lg flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
                     <span class="material-symbols-outlined text-secondary text-3xl" data-icon="forum">forum</span>
                 </div>
                 <h3 class="font-headline font-bold text-lg text-secondary mb-1">커뮤니케이션</h3>
                 <p class="text-on-surface-variant text-sm">연구 동료 및 교수진과 소통하세요.</p>
-            </div>
+            </a>
             <!-- My Classroom -->
             <div class="bg-surface-container-lowest p-8 rounded-xl shadow-sm hover:shadow-md transition-all group cursor-pointer border-l-4 border-tertiary">
                 <div class="w-12 h-12 bg-tertiary-fixed/30 rounded-lg flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">


### PR DESCRIPTION
  ## 📌 PR 유형
  <!-- 해당하는 항목에 체크하세요 -->
  - [x] ✨ FEATURE
  - [x] 🔧 UPDATE
  - [ ] 🐛 BUGFIX
  - [ ] ♻️ REFACTOR
  - [ ] 📝 DOCS
  
  ---
  
  ## 🔗 관련 이슈
  Closes #42 
  
  ---
  
  ## 🛠️ 작업 내용
- 댓글 등록, 수정, 삭제 기능을 구현했습니다.
- 댓글 작성자 이름 표시 및 댓글 권한 처리를 추가했습니다.
- 대댓글 화면 출력 및 답글 등록 폼을 상세 페이지에 반영했습니다.
  
  ---
  
  ## 🔄 변경 사항
- 게시글 상세 화면에서 댓글 목록 조회, 댓글 등록, 댓글 수정, 댓글 삭제가 가능하도록 구현했습니다.
- 댓글 권한을 게시판 종류와 역할 기준으로 분기하고, 권한이 없을 때는 상세 화면으로 복귀 후 알림이 뜨도록 수정했습니다.
- 댓글 관리 버튼은 권한이 있는 경우에만 보이도록 프론트 표시 로직을 추가했습니다.
- parentCommentId를 활용해 부모 댓글과 대댓글이 구분되어 보이도록 상세 화면 구조를 변경했습니다.
- 게시글 삭제 및 댓글 삭제 시 확인창이 뜨도록 confirm()을 추가했습니다.
  
  ---
  
  ## ✅ 체크리스트
  - [x] 팀 코딩 컨벤션을 준수했습니다.
  - [ ] 정상적으로 빌드 및 실행됩니다.
  - [ ] 불필요한 코드는 제거했습니다.
  - [ ] 관련 문서를 업데이트했습니다 (필요한 경우).