### PR TITLE
[REFACTOR] 캘린더에 시험 일정(8번째 섹션 기준 3일 뒤로) 기능 구현

### DIFF
--- a/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/service/CalenderService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/calendar/model/service/CalenderService.java
@@ -61,6 +61,18 @@ public class CalenderService {
                     .collect(Collectors.toList());
 
             result.addAll(sectionEvents);
+
+            List<CalendarEventDTO> examEvents = courses.stream()
+                    .filter(course -> course.getExamDueDate() != null)
+                    .map(course -> new CalendarEventDTO(
+                            "exam-" + course.getCourseId(),
+                            course.getTitle() + " - 시험 마감",
+                            course.getExamDueDate().toString(),
+                            "#ef4444"
+                    ))
+                    .collect(Collectors.toList());
+
+            result.addAll(examEvents);
         }
 
         List<CalendarEventDTO> memoEvents = calendarMemoRepository.findByMemberId(memberId)
@@ -75,7 +87,11 @@ public class CalenderService {
 
         result.addAll(memoEvents);
 
+
+
         return result;
+
+
     }
 
     public List<CalendarEventDTO> findInstructorCalendarEvents(Integer instructorId) {
@@ -125,7 +141,22 @@ public class CalenderService {
 
         result.addAll(memoEvents);
 
+        List<CalendarEventDTO> examEvents = courses.stream()
+                .filter(course -> course.getExamDueDate() != null)
+                .map(course -> new CalendarEventDTO(
+                        "exam-" + course.getCourseId(),
+                        course.getTitle() + " - 시험 마감",
+                        course.getExamDueDate().toString(),
+                        "#ef4444"
+                ))
+                .collect(Collectors.toList());
+
+        result.addAll(examEvents);
+
         return result;
+
+
+
     }
 
     public List<CalendarMemoDTO> findMemosByDate(Integer memberId, String date) {

--- a/src/main/java/com/wanted/projectmodule2lms/domain/course/model/entity/Course.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/course/model/entity/Course.java
@@ -67,6 +67,9 @@ public class Course {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @Column(name = "exam_due_date")
+    private LocalDate examDueDate;
+
     public void changeCourseInfo(String title,
                                  String description,
                                  String category,
@@ -120,5 +123,8 @@ public class Course {
         this.reviewedBy = adminId;
         this.reviewedAt = LocalDateTime.now();
         this.deletedAt = LocalDateTime.now();
+    }
+    public void changeExamDueDate(LocalDate examDueDate) {
+        this.examDueDate = examDueDate;
     }
 }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/course/service/CourseService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/course/service/CourseService.java
@@ -157,6 +157,7 @@ public class CourseService {
                 null,
                 null,
                 null,
+                null,
                 null
         );
 

--- a/src/main/java/com/wanted/projectmodule2lms/domain/section/model/dao/SectionRepository.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/section/model/dao/SectionRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface SectionRepository extends JpaRepository<Section, Integer> {
 
@@ -20,6 +21,8 @@ public interface SectionRepository extends JpaRepository<Section, Integer> {
 
 
     long countByCourseId(Integer courseId);
+
+    Optional<Section> findByCourseIdAndSectionOrder(Integer courseId, Integer sectionOrder);
 
 }
 

--- a/src/main/java/com/wanted/projectmodule2lms/domain/section/service/SectionService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/section/service/SectionService.java
@@ -66,6 +66,7 @@ public class SectionService {
         );
 
         sectionRepository.save(section);
+        updateExamDueDate(courseId);
         return section.getSectionId();
     }
 
@@ -93,6 +94,8 @@ public class SectionService {
                 updateDTO.getSectionOrder(),
                 updateDTO.getOpenDate()
         );
+
+        updateExamDueDate(foundSection.getCourseId());
     }
 
     @Transactional
@@ -107,7 +110,9 @@ public class SectionService {
             throw new IllegalArgumentException("승인된 코스의 섹션은 삭제할 수 없습니다.");
         }
 
+        Integer courseId = foundSection.getCourseId();
         sectionRepository.deleteById(sectionId);
+        updateExamDueDate(courseId);
     }
 
     public List<SectionDTO> findMySections(Integer memberId, Integer courseId) {
@@ -142,6 +147,21 @@ public class SectionService {
         }
 
         return modelMapper.map(foundSection, SectionDTO.class);
+    }
+
+    private void updateExamDueDate(Integer courseId) {
+        Section lastSection = sectionRepository.findByCourseIdAndSectionOrder(courseId, 8)
+                .orElse(null);
+
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 코스가 존재하지 않습니다."));
+
+        if (lastSection == null || lastSection.getOpenDate() == null) {
+            course.changeExamDueDate(null);
+            return;
+        }
+
+        course.changeExamDueDate(lastSection.getOpenDate().plusDays(3));
     }
 
 }


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당하는 항목에 체크하세요 -->
- [ ] ✨ FEATURE
- [ ] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [x] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 🔗 관련 이슈
Closes #57 

---

## 🛠️ 작업 내용
- course와 section db 등 수정으로 기능 구현 
- 
- 

---

## 🔄 변경 사항
- 코스 마감일을 기준으로 시험 일정을 계산하는 것에서 8번째 섹션으로 계산 하는 것으로 변경 
- 
- 

---

## ✅ 체크리스트
- [x] 팀 코딩 컨벤션을 준수했습니다.
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 불필요한 코드는 제거했습니다.
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우).