### PR TITLE
[FEATURE]  강사의 학생 출결 관리 기능 구현

### DIFF
--- a/src/main/java/com/wanted/projectmodule2lms/domain/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/attendance/controller/AttendanceController.java
@@ -2,7 +2,8 @@ package com.wanted.projectmodule2lms.domain.attendance.controller;
 
 import com.wanted.projectmodule2lms.domain.attendance.model.dto.AttendanceCheckResponseDTO;
 import com.wanted.projectmodule2lms.domain.attendance.model.service.AttendanceService;
-import com.wanted.projectmodule2lms.global.util.SecurityUtil;
+import com.wanted.projectmodule2lms.global.annotation.AuditLog;
+import com.wanted.projectmodule2lms.global.annotation.LoginMemberId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -27,27 +28,25 @@ public class AttendanceController {
     @GetMapping("/{courseId}/{sectionId}")
     public ModelAndView attendancePage(@PathVariable Integer courseId,
                                        @PathVariable Integer sectionId,
+                                       @LoginMemberId Long loginMemberId,
                                        ModelAndView mv) {
-        Integer memberId = getCurrentMemberId();
+        Integer memberId = loginMemberId != null ? loginMemberId.intValue() : null;
         mv.addObject("attendancePage", attendanceService.findAttendancePage(memberId, courseId, sectionId));
         mv.setViewName("student/attendance/attendancepage");
         return mv;
     }
 
+    @AuditLog
     @PostMapping("/check")
     @ResponseBody
-    public ResponseEntity<AttendanceCheckResponseDTO> checkAttendance(@RequestParam Integer sectionId,
+    public ResponseEntity<AttendanceCheckResponseDTO> checkAttendance(@LoginMemberId Long loginMemberId,
+                                                                      @RequestParam Integer sectionId,
                                                                       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime checkedAt) {
-        Integer memberId = getCurrentMemberId();
+        Integer memberId = loginMemberId != null ? loginMemberId.intValue() : null;
         try {
             return ResponseEntity.ok(attendanceService.checkAttendance(memberId, sectionId, checkedAt));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(new AttendanceCheckResponseDTO(null, e.getMessage()));
         }
-    }
-
-    private Integer getCurrentMemberId() {
-        Long currentMemberId = SecurityUtil.getCurrentMemberId();
-        return currentMemberId != null ? currentMemberId.intValue() : null;
     }
 }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/attendance/model/dao/AttendanceRepository.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/attendance/model/dao/AttendanceRepository.java
@@ -15,4 +15,5 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Integer>
 
     List<Attendance> findByEnrollmentId(Integer enrollmentId);
 
+    List<Attendance> findByEnrollmentIdOrderBySectionIdAsc(Integer enrollmentId);
 }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/board/controller/BoardController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/board/controller/BoardController.java
@@ -9,6 +9,8 @@ import com.wanted.projectmodule2lms.domain.course.model.entity.Course;
 import com.wanted.projectmodule2lms.domain.member.model.dao.MemberRepository;
 import com.wanted.projectmodule2lms.domain.member.model.entity.Member;
 import com.wanted.projectmodule2lms.domain.member.model.entity.MemberRole;
+import com.wanted.projectmodule2lms.global.annotation.AuditLog;
+import com.wanted.projectmodule2lms.global.annotation.LoginMemberId;
 import com.wanted.projectmodule2lms.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -83,8 +85,9 @@ public class BoardController {
     @GetMapping("/section-qna")
     public String sectionQnaListPage(@RequestParam(required = false) String keyword,
                                      @RequestParam(required = false) Integer courseId,
+                                     @LoginMemberId Long loginMemberId,
                                      Model model) {
-        Integer currentMemberId = getCurrentMemberId();
+        Integer currentMemberId = loginMemberId != null ? loginMemberId.intValue() : null;
         MemberRole currentRole = getCurrentMemberRole();
         List<BoardDTO> boardList;
 
@@ -121,8 +124,9 @@ public class BoardController {
     public String boardRegistPage(@RequestParam(defaultValue = "FREE") BoardType type,
                                   @RequestParam(required = false) Integer courseId,
                                   @RequestParam(required = false) Integer sectionId,
+                                  @LoginMemberId Long loginMemberId,
                                   Model model) {
-        Integer currentMemberId = getCurrentMemberId();
+        Integer currentMemberId = loginMemberId != null ? loginMemberId.intValue() : null;
         MemberRole currentRole = getCurrentMemberRole();
 
         List<Course> courses = (currentMemberId != null && currentRole != null)
@@ -145,10 +149,12 @@ public class BoardController {
         return "board/regist";
     }
 
+    @AuditLog
     @PostMapping("/regist")
-    public String registBoard(@ModelAttribute BoardDTO boardDTO,
+    public String registBoard(@LoginMemberId Long loginMemberId,
+                              @ModelAttribute BoardDTO boardDTO,
                               RedirectAttributes redirectAttributes) {
-        Integer currentMemberId = getCurrentMemberId();
+        Integer currentMemberId = loginMemberId != null ? loginMemberId.intValue() : null;
         MemberRole currentRole = getCurrentMemberRole();
 
         try {
@@ -170,10 +176,12 @@ public class BoardController {
         return "board/modify";
     }
 
+    @AuditLog
     @PostMapping("/modify")
-    public String modifyBoard(@ModelAttribute BoardDTO boardDTO,
+    public String modifyBoard(@LoginMemberId Long loginMemberId,
+                              @ModelAttribute BoardDTO boardDTO,
                               RedirectAttributes redirectAttributes) {
-        Integer currentMemberId = getCurrentMemberId();
+        Integer currentMemberId = loginMemberId != null ? loginMemberId.intValue() : null;
         MemberRole currentRole = getCurrentMemberRole();
 
         try {
@@ -193,10 +201,12 @@ public class BoardController {
         return "board/delete";
     }
 
+    @AuditLog
     @PostMapping("/delete")
-    public String deleteBoard(@RequestParam Integer postId,
+    public String deleteBoard(@LoginMemberId Long loginMemberId,
+                              @RequestParam Integer postId,
                               RedirectAttributes redirectAttributes) {
-        Integer currentMemberId = getCurrentMemberId();
+        Integer currentMemberId = loginMemberId != null ? loginMemberId.intValue() : null;
         MemberRole currentRole = getCurrentMemberRole();
         BoardDTO board = boardService.findBoardById(postId);
         try {

--- a/src/main/java/com/wanted/projectmodule2lms/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/comment/controller/CommentController.java
@@ -5,6 +5,8 @@ import com.wanted.projectmodule2lms.domain.comment.model.service.CommentService;
 import com.wanted.projectmodule2lms.domain.member.model.dao.MemberRepository;
 import com.wanted.projectmodule2lms.domain.member.model.entity.Member;
 import com.wanted.projectmodule2lms.domain.member.model.entity.MemberRole;
+import com.wanted.projectmodule2lms.global.annotation.AuditLog;
+import com.wanted.projectmodule2lms.global.annotation.LoginMemberId;
 import com.wanted.projectmodule2lms.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -22,10 +24,12 @@ public class CommentController {
     private final CommentService commentService;
     private final MemberRepository memberRepository;
 
+    @AuditLog
     @PostMapping("/regist")
-    public String registerComment(@ModelAttribute CommentDTO commentDTO,
+    public String registerComment(@LoginMemberId Long loginMemberId,
+                                  @ModelAttribute CommentDTO commentDTO,
                                   RedirectAttributes redirectAttributes) {
-        Integer currentMemberId = getCurrentMemberId();
+        Integer currentMemberId = loginMemberId != null ? loginMemberId.intValue() : null;
         MemberRole currentRole = getCurrentMemberRole();
 
         try {
@@ -37,10 +41,12 @@ public class CommentController {
         }
     }
 
+    @AuditLog
     @PostMapping("/modify")
-    public String modifyComment(@ModelAttribute CommentDTO commentDTO,
+    public String modifyComment(@LoginMemberId Long loginMemberId,
+                                @ModelAttribute CommentDTO commentDTO,
                                 RedirectAttributes redirectAttributes) {
-        Integer currentMemberId = getCurrentMemberId();
+        Integer currentMemberId = loginMemberId != null ? loginMemberId.intValue() : null;
         MemberRole currentRole = getCurrentMemberRole();
 
         try {
@@ -52,11 +58,13 @@ public class CommentController {
         }
     }
 
+    @AuditLog
     @PostMapping("/delete")
-    public String deleteComment(@RequestParam Integer commentId,
+    public String deleteComment(@LoginMemberId Long loginMemberId,
+                                @RequestParam Integer commentId,
                                 @RequestParam Integer postId,
                                 RedirectAttributes redirectAttributes) {
-        Integer currentMemberId = getCurrentMemberId();
+        Integer currentMemberId = loginMemberId != null ? loginMemberId.intValue() : null;
         MemberRole currentRole = getCurrentMemberRole();
 
         try {
@@ -68,13 +76,9 @@ public class CommentController {
         }
     }
 
-    private Integer getCurrentMemberId() {
-        Long currentMemberId = SecurityUtil.getCurrentMemberId();
-        return currentMemberId != null ? currentMemberId.intValue() : null;
-    }
-
     private MemberRole getCurrentMemberRole() {
-        Integer currentMemberId = getCurrentMemberId();
+        Long loginMemberId = SecurityUtil.getCurrentMemberId();
+        Integer currentMemberId = loginMemberId != null ? loginMemberId.intValue() : null;
 
         if (currentMemberId == null) {
             return null;

--- a/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/service/CommentService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/service/CommentService.java
@@ -31,7 +31,7 @@ public class CommentService {
     private final CourseRepository courseRepository;
     private final EnrollmentRepository enrollmentRepository;
 
-    public List<CommentDTO> findCommentsByPostId(Integer postId) {
+        public List<CommentDTO> findCommentsByPostId(Integer postId) {
         List<Comment> commentList = commentRepository.findByPostIdAndIsDeletedFalseOrderByCommentIdAsc(postId);
 
         return commentList.stream()

--- a/src/main/java/com/wanted/projectmodule2lms/domain/grade/controller/InstructorGradeController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/grade/controller/InstructorGradeController.java
@@ -29,7 +29,7 @@ public class InstructorGradeController {
         Integer instructorId = currentMemberId.intValue();
 
         model.addAttribute("grades", gradeService.findGradesByInstructorId(instructorId));
-        return "instructor/grade/list";
+        return "instructor/grade/list-view";
     }
 
     // 성적 수정 페이지 이동

--- a/src/main/java/com/wanted/projectmodule2lms/domain/grade/model/dto/GradeDTO.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/grade/model/dto/GradeDTO.java
@@ -15,6 +15,7 @@ public class GradeDTO {
 
     private Integer gradeId;
     private Integer enrollmentId;
+    private Integer courseId;
     private String studentName;
     private String courseTitle;
     private BigDecimal attendanceScore;

--- a/src/main/java/com/wanted/projectmodule2lms/domain/grade/model/service/GradeService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/grade/model/service/GradeService.java
@@ -55,6 +55,7 @@ public class GradeService {
             GradeDTO gradeDTO = new GradeDTO(
                     grade.getGradeId(),
                     grade.getEnrollmentId(),
+                    enrollment.getCourseId(),
                     studentName,
                     courseTitle,
                     grade.getAttendanceScore(),
@@ -136,6 +137,7 @@ public class GradeService {
                 GradeDTO gradeDTO = new GradeDTO(
                         grade.getGradeId(),
                         grade.getEnrollmentId(),
+                        enrollment.getCourseId(),
                         studentName,
                         course.getTitle(),
                         grade.getAttendanceScore(),
@@ -177,6 +179,7 @@ public class GradeService {
         return new GradeDTO(
                 grade.getGradeId(),
                 grade.getEnrollmentId(),
+                enrollment.getCourseId(),
                 studentName,
                 course.getTitle(),
                 grade.getAttendanceScore(),

--- a/src/main/java/com/wanted/projectmodule2lms/domain/instructorgrade/controller/InstructorGradeController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/instructorgrade/controller/InstructorGradeController.java
@@ -1,0 +1,4 @@
+package com.wanted.projectmodule2lms.domain.instructorgrade.controller;
+
+class InstructorGradeControllerBackup {
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/instructorgrade/controller/InstructorGradeManageController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/instructorgrade/controller/InstructorGradeManageController.java
@@ -1,0 +1,39 @@
+package com.wanted.projectmodule2lms.domain.instructorgrade.controller;
+
+import com.wanted.projectmodule2lms.domain.instructorgrade.model.service.InstructorGradeService;
+import com.wanted.projectmodule2lms.global.annotation.AuditLog;
+import com.wanted.projectmodule2lms.global.annotation.LoginMemberId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.http.ResponseEntity;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/instructor/grades")
+public class InstructorGradeManageController {
+    private final InstructorGradeService instructorGradeService;
+
+    @GetMapping("/manage")
+    public String managePage(@RequestParam Integer courseId, Model model) {
+     model.addAttribute("studentList",instructorGradeService.findStudentsByCourse(courseId));
+     model.addAttribute("courseId", courseId);
+        return "instructor/grade/managepage";
+    }
+
+    @AuditLog
+    @PostMapping("/manage/attendance")
+    @ResponseBody
+    public ResponseEntity<String> updateAttendance(@LoginMemberId Long loginMemberId,
+                                                   @RequestParam Integer enrollmentId,
+                                                   @RequestParam Integer sectionId,
+                                                   @RequestParam String status) {
+        instructorGradeService.updateAttendanceStatus(loginMemberId.intValue(), enrollmentId, sectionId, status);
+        return ResponseEntity.ok("ok");
+    }
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/instructorgrade/model/dto/InstructorStudentManageDTO.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/instructorgrade/model/dto/InstructorStudentManageDTO.java
@@ -1,0 +1,25 @@
+package com.wanted.projectmodule2lms.domain.instructorgrade.model.dto;
+
+import com.wanted.projectmodule2lms.domain.section.model.dto.SectionAttendanceDTO;
+import lombok.*;
+
+import java.util.List;
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class InstructorStudentManageDTO {
+
+    private Integer memberId;
+    private Integer enrollmentId;
+    private String studentName;
+    private String email;
+    private Integer progressRate;
+    private String attendanceSummary;
+    private Double assignmentScore;
+    private Double examScore;
+    private Double attitudeScore;
+    private String attitudeMemo;
+    private List<SectionAttendanceDTO> sectionAttendanceList;
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/instructorgrade/model/service/InstructorGradeService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/instructorgrade/model/service/InstructorGradeService.java
@@ -1,0 +1,173 @@
+package com.wanted.projectmodule2lms.domain.instructorgrade.model.service;
+
+
+import com.wanted.projectmodule2lms.domain.attendance.model.dao.AttendanceRepository;
+import com.wanted.projectmodule2lms.domain.attendance.model.entity.Attendance;
+import com.wanted.projectmodule2lms.domain.attendance.model.entity.AttendanceStatus;
+import com.wanted.projectmodule2lms.domain.course.model.dao.CourseRepository;
+import com.wanted.projectmodule2lms.domain.course.model.entity.Course;
+import com.wanted.projectmodule2lms.domain.enrollment.model.dao.EnrollmentRepository;
+import com.wanted.projectmodule2lms.domain.enrollment.model.entity.Enrollment;
+import com.wanted.projectmodule2lms.domain.grade.model.dao.GradeRepository;
+import com.wanted.projectmodule2lms.domain.grade.model.entity.Grade;
+import com.wanted.projectmodule2lms.domain.instructorgrade.model.dto.InstructorStudentManageDTO;
+import com.wanted.projectmodule2lms.domain.member.model.dao.MemberRepository;
+import com.wanted.projectmodule2lms.domain.member.model.entity.Member;
+import com.wanted.projectmodule2lms.domain.section.model.dao.SectionRepository;
+import com.wanted.projectmodule2lms.domain.section.model.dto.SectionAttendanceDTO;
+import com.wanted.projectmodule2lms.domain.section.model.entity.Section;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InstructorGradeService {
+    private final EnrollmentRepository enrollmentRepository;
+    private final MemberRepository memberRepository;
+    private final GradeRepository gradeRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final SectionRepository sectionRepository;
+    private final CourseRepository courseRepository;
+
+    public List<InstructorStudentManageDTO> findStudentsByCourse(Integer courseId) {
+        List<InstructorStudentManageDTO> studentList = new ArrayList<>();
+
+        List<Enrollment> enrollmentList = enrollmentRepository.findByCourseId(courseId);
+        List<Section> sectionList = sectionRepository.findByCourseIdOrderBySectionOrderAsc(courseId);
+
+        for (Enrollment enrollment : enrollmentList) {
+            Member member = memberRepository.findById(enrollment.getMemberId()).orElse(null);
+            Grade grade = gradeRepository.findByEnrollmentId(enrollment.getEnrollmentId()).orElse(null);
+            List<Attendance> attendanceList =
+                    attendanceRepository.findByEnrollmentIdOrderBySectionIdAsc(enrollment.getEnrollmentId());
+
+            if (member == null) {
+                continue;
+            }
+
+            InstructorStudentManageDTO dto = new InstructorStudentManageDTO();
+            dto.setMemberId(member.getMemberId());
+            dto.setEnrollmentId(enrollment.getEnrollmentId());
+            dto.setStudentName(member.getName());
+            dto.setEmail(member.getEmail());
+            dto.setProgressRate(calculateProgressRate(sectionList.size(), attendanceList.size()));
+            dto.setAttendanceSummary(makeAttendanceSummary(attendanceList));
+            dto.setAssignmentScore(
+                    grade != null && grade.getAssignmentScore() != null ? grade.getAssignmentScore().doubleValue() : null
+            );
+            dto.setExamScore(
+                    grade != null && grade.getExamScore() != null ? grade.getExamScore().doubleValue() : null
+            );
+            dto.setAttitudeScore(
+                    grade != null && grade.getAttitudeScore() != null ? grade.getAttitudeScore().doubleValue() : null
+            );
+            dto.setSectionAttendanceList(makeSectionAttendanceList(sectionList, attendanceList));
+            studentList.add(dto);
+        }
+
+        return studentList;
+    }
+
+    @Transactional
+    public void updateAttendanceStatus(Integer instructorId,
+                                       Integer enrollmentId,
+                                       Integer sectionId,
+                                       String status) {
+        Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
+                .orElseThrow(() -> new IllegalArgumentException("수강 정보가 없습니다."));
+
+        Section section = sectionRepository.findById(sectionId)
+                .orElseThrow(() -> new IllegalArgumentException("섹션 정보가 없습니다."));
+
+        if (!enrollment.getCourseId().equals(section.getCourseId())) {
+            throw new IllegalArgumentException("코스 정보가 일치하지 않습니다.");
+        }
+
+        Course course = courseRepository.findById(enrollment.getCourseId())
+                .orElseThrow(() -> new IllegalArgumentException("코스 정보가 없습니다."));
+
+        if (!course.getInstructorId().equals(instructorId)) {
+            throw new IllegalArgumentException("해당 강의 담당 강사만 출결을 수정할 수 있습니다.");
+        }
+
+        AttendanceStatus attendanceStatus = AttendanceStatus.valueOf(status);
+
+        Attendance attendance = attendanceRepository.findByEnrollmentIdAndSectionId(enrollmentId, sectionId)
+                .orElse(null);
+
+        if (attendance == null) {
+            attendanceRepository.save(new Attendance(
+                    enrollmentId,
+                    sectionId,
+                    attendanceStatus,
+                    LocalDateTime.now(),
+                    "강사 변경"
+            ));
+            return;
+        }
+
+        attendance.changeAttendance(attendanceStatus, LocalDateTime.now(), "강사 변경");
+    }
+
+    private Integer calculateProgressRate(int totalSectionCount, int attendedCount) {
+        if (totalSectionCount == 0) {
+            return 0;
+        }
+
+        return (attendedCount * 100) / totalSectionCount;
+    }
+
+    private String makeAttendanceSummary(List<Attendance> attendanceList) {
+        int presentCount = 0;
+        int lateCount = 0;
+        int absentCount = 0;
+
+        for (Attendance attendance : attendanceList) {
+            if (attendance.getStatus() == AttendanceStatus.PRESENT) {
+                presentCount++;
+            } else if (attendance.getStatus() == AttendanceStatus.LATE) {
+                lateCount++;
+            } else if (attendance.getStatus() == AttendanceStatus.ABSENT) {
+                absentCount++;
+            }
+        }
+
+        return "출석 " + presentCount + " / 지각 " + lateCount + " / 결석 " + absentCount;
+    }
+
+    private List<SectionAttendanceDTO> makeSectionAttendanceList(List<Section> sectionList,
+                                                                 List<Attendance> attendanceList) {
+        List<SectionAttendanceDTO> sectionAttendanceList = new ArrayList<>();
+
+        for (Section section : sectionList) {
+            SectionAttendanceDTO sectionAttendanceDTO = new SectionAttendanceDTO();
+            sectionAttendanceDTO.setSectionId(section.getSectionId());
+            sectionAttendanceDTO.setSectionTitle(section.getTitle());
+            sectionAttendanceDTO.setStatus(findAttendanceStatus(section, attendanceList));
+            sectionAttendanceList.add(sectionAttendanceDTO);
+        }
+
+        return sectionAttendanceList;
+    }
+
+    private String findAttendanceStatus(Section section, List<Attendance> attendanceList) {
+        for (Attendance attendance : attendanceList) {
+            if (attendance.getSectionId().equals(section.getSectionId())) {
+                return attendance.getStatus().name();
+            }
+        }
+
+        if (section.getOpenDate() != null && section.getOpenDate().isAfter(LocalDate.now())) {
+            return "NOT_OPEN";
+        }
+
+        return "UNCHECKED";
+    }
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/member/model/service/MailService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/member/model/service/MailService.java
@@ -1,36 +1,51 @@
 package com.wanted.projectmodule2lms.domain.member.model.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class MailService {
 
-    private final JavaMailSender mailSender;
+    private final ObjectProvider<JavaMailSender> mailSenderProvider;
 
-    // 승인 메일 보내기
     public void sendApprovalEmail(String toEmail, String approvalCode) {
+        JavaMailSender mailSender = mailSenderProvider.getIfAvailable();
+
+        if (mailSender == null) {
+            log.info("메일 설정이 없어 승인 메일 전송을 건너뜀. toEmail={}, approvalCode={}", toEmail, approvalCode);
+            return;
+        }
+
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(toEmail);
         message.setSubject("[64Lab] 강사 가입 승인 안내");
-        message.setText("축하드립니다! 강사 가입 신청이 승인되었습니다.\n\n" +
-                "로그인 후 아래의 승인 코드를 입력하여 계정을 활성화해주세요.\n" +
-                "승인 코드 : " + approvalCode);
+        message.setText("축하합니다! 강사 가입 요청이 승인되었습니다.\n\n"
+                + "로그인 후 아래 승인 코드를 입력해 계정을 활성화해주세요.\n"
+                + "승인 코드 : " + approvalCode);
 
         mailSender.send(message);
     }
 
-    // 반려 메일 보내기
     public void sendRejectEmail(String toEmail, String reason) {
+        JavaMailSender mailSender = mailSenderProvider.getIfAvailable();
+
+        if (mailSender == null) {
+            log.info("메일 설정이 없어 반려 메일 전송을 건너뜀. toEmail={}, reason={}", toEmail, reason);
+            return;
+        }
+
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(toEmail);
         message.setSubject("[64Lab] 강사 가입 반려 안내");
-        message.setText("안녕하세요. 가입 신청하신 내용에 보완이 필요하여 반려되었습니다.\n\n" +
-                "반려 사유 : " + reason + "\n\n" +
-                "사유를 확인하신 후 다시 신청해주시기 바랍니다.");
+        message.setText("안녕하세요. 강사 가입 요청 내용에 보완이 필요해 반려되었습니다.\n\n"
+                + "반려 사유 : " + reason + "\n\n"
+                + "사유를 확인한 뒤 다시 요청해주세요.");
 
         mailSender.send(message);
     }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/section/model/dto/SectionAttendanceDTO.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/section/model/dto/SectionAttendanceDTO.java
@@ -1,0 +1,14 @@
+package com.wanted.projectmodule2lms.domain.section.model.dto;
+
+import lombok.*;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class SectionAttendanceDTO {
+    private Integer sectionId;
+    private String sectionTitle;
+    private String status;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,4 +29,4 @@ spring:
         format_sql: true
 
   config:
-    import: classpath:application-secret.yml
+    import: optional:classpath:application-secret.yml

--- a/src/main/resources/templates/instructor/grade/list-view.html
+++ b/src/main/resources/templates/instructor/grade/list-view.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>수강생 성적 목록</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            background-color: #f5f7fb;
+            color: #222;
+        }
+
+        .page-wrapper {
+            max-width: 1400px;
+            margin: 0 auto;
+            padding: 32px 24px 48px;
+        }
+
+        h2 {
+            margin: 0 0 20px;
+            font-size: 40px;
+        }
+
+        .page-desc {
+            margin: 0 0 20px;
+            color: #666;
+        }
+
+        .table-wrapper {
+            background-color: #fff;
+            border: 1px solid #ddd;
+            border-radius: 12px;
+            overflow-x: auto;
+            padding: 16px;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        th, td {
+            border: 1px solid #d9d9d9;
+            padding: 12px 14px;
+            text-align: center;
+        }
+
+        th {
+            background-color: #f1f5f9;
+            white-space: nowrap;
+        }
+
+        .button-group {
+            display: flex;
+            justify-content: center;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+
+        .action-link {
+            display: inline-block;
+            padding: 8px 12px;
+            border-radius: 8px;
+            text-decoration: none;
+            font-size: 14px;
+            font-weight: bold;
+        }
+
+        .edit-link {
+            background-color: #eff6ff;
+            color: #1d4ed8;
+        }
+
+        .manage-link {
+            background-color: #ecfdf5;
+            color: #047857;
+        }
+    </style>
+</head>
+<body>
+<div class="page-wrapper">
+    <h2>수강생 성적 목록</h2>
+    <p class="page-desc">임시 버튼으로 학생 통합 관리 화면에 바로 들어갈 수 있다.</p>
+
+    <div class="table-wrapper">
+        <table>
+            <thead>
+            <tr>
+                <th>학생 이름</th>
+                <th>강의명</th>
+                <th>출석 점수</th>
+                <th>과제 점수</th>
+                <th>시험 점수</th>
+                <th>태도 점수</th>
+                <th>총점</th>
+                <th>이수 여부</th>
+                <th>성적 관리</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="grade : ${grades}">
+                <td th:text="${grade.studentName}">김학생</td>
+                <td th:text="${grade.courseTitle}">Spring Boot 입문</td>
+                <td th:text="${grade.attendanceScore}">90.00</td>
+                <td th:text="${grade.assignmentScore}">95.00</td>
+                <td th:text="${grade.examScore}">88.00</td>
+                <td th:text="${grade.attitudeScore}">92.00</td>
+                <td th:text="${grade.totalScore}">91.05</td>
+                <td th:text="${grade.completionStatus}">수료</td>
+                <td>
+                    <div class="button-group">
+                        <a class="action-link edit-link"
+                           th:href="@{/instructor/grades/edit(enrollmentId=${grade.enrollmentId})}">
+                            성적 등록/수정
+                        </a>
+                        <a class="action-link manage-link"
+                           th:href="@{/instructor/grades/manage(courseId=${grade.courseId})}">
+                            관리 화면
+                        </a>
+                    </div>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/instructor/grade/manage-view.html
+++ b/src/main/resources/templates/instructor/grade/manage-view.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>학생 명단 및 관리</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: Arial, sans-serif;
+            background-color: #f4f6f8;
+            color: #222;
+        }
+
+        .page-wrapper {
+            max-width: 1600px;
+            margin: 0 auto;
+            padding: 32px 24px 48px;
+        }
+
+        .top-bar {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        .title-group h1 {
+            margin: 0 0 8px;
+            font-size: 32px;
+        }
+
+        .title-group p {
+            margin: 0;
+            color: #666;
+        }
+
+        .top-actions {
+            display: flex;
+            gap: 10px;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+
+        .course-badge {
+            display: inline-block;
+            padding: 8px 14px;
+            border-radius: 999px;
+            background-color: #e8f0ff;
+            color: #1d4ed8;
+            font-weight: bold;
+        }
+
+        .back-link {
+            display: inline-block;
+            padding: 10px 14px;
+            border-radius: 10px;
+            background-color: #334155;
+            color: #fff;
+            text-decoration: none;
+            font-weight: bold;
+        }
+
+        .table-wrapper {
+            overflow-x: auto;
+            background-color: #fff;
+            border: 1px solid #ddd;
+            border-radius: 12px;
+            padding: 16px;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            min-width: 1450px;
+        }
+
+        th, td {
+            border: 1px solid #e1e1e1;
+            padding: 12px;
+            text-align: center;
+            vertical-align: middle;
+        }
+
+        th {
+            background-color: #f8fafc;
+            font-size: 14px;
+            white-space: nowrap;
+        }
+
+        td {
+            background-color: #fff;
+            font-size: 14px;
+        }
+
+        .student-col {
+            min-width: 120px;
+            font-weight: bold;
+        }
+
+        .email-col {
+            min-width: 200px;
+        }
+
+        .summary-col {
+            min-width: 180px;
+        }
+
+        .score-col {
+            min-width: 100px;
+        }
+
+        .section-box {
+            min-width: 150px;
+        }
+
+        .attendance-select {
+            width: 100%;
+            min-width: 120px;
+            padding: 8px 10px;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font-size: 13px;
+            font-weight: bold;
+            background-color: #fff;
+        }
+
+        .status-present {
+            background-color: #e8f7ec;
+            color: #166534;
+        }
+
+        .status-late {
+            background-color: #fff7db;
+            color: #a16207;
+        }
+
+        .status-absent {
+            background-color: #fdecec;
+            color: #b91c1c;
+        }
+
+        .status-unchecked {
+            background-color: #eef2f7;
+            color: #475569;
+        }
+
+        .status-not-open {
+            background-color: #f1f5f9;
+            color: #64748b;
+        }
+
+        .save-message {
+            min-height: 22px;
+            margin: 0 0 16px;
+            font-weight: bold;
+            color: #0f766e;
+        }
+
+        .save-message.error {
+            color: #b91c1c;
+        }
+
+        .empty-message {
+            padding: 24px;
+            text-align: center;
+            color: #666;
+        }
+    </style>
+</head>
+<body>
+<div class="page-wrapper">
+    <div class="top-bar">
+        <div class="title-group">
+            <h1>학생 명단 및 관리</h1>
+            <p>한 화면에서 학생 성적과 섹션별 출결 상태를 함께 관리할 수 있다.</p>
+        </div>
+        <div class="top-actions">
+            <div class="course-badge" th:text="|코스 ID: ${courseId}|">코스 ID: 1</div>
+            <a class="back-link" th:href="@{/instructor/grades}">성적 목록으로 돌아가기</a>
+        </div>
+    </div>
+
+    <p class="save-message" id="saveMessage"></p>
+
+    <div class="table-wrapper" th:if="${studentList != null and !#lists.isEmpty(studentList)}">
+        <table>
+            <thead>
+            <tr>
+                <th class="student-col">학생 이름</th>
+                <th class="email-col">이메일</th>
+                <th>진도율</th>
+                <th class="summary-col">출결 요약</th>
+                <th class="score-col">과제 점수</th>
+                <th class="score-col">시험 점수</th>
+                <th class="score-col">태도 점수</th>
+                <th th:each="section : ${studentList[0].sectionAttendanceList}"
+                    class="section-box"
+                    th:text="${section.sectionTitle}">
+                    섹션명
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="student : ${studentList}">
+                <td class="student-col" th:text="${student.studentName}">김학생</td>
+                <td class="email-col" th:text="${student.email}">student@test.com</td>
+                <td th:text="|${student.progressRate}%|">50%</td>
+                <td class="summary-col" th:text="${student.attendanceSummary}">출석 3 / 지각 1 / 결석 0</td>
+                <td class="score-col" th:text="${student.assignmentScore}">95.0</td>
+                <td class="score-col" th:text="${student.examScore}">88.0</td>
+                <td class="score-col" th:text="${student.attitudeScore}">92.0</td>
+                <td th:each="sectionAttendance : ${student.sectionAttendanceList}" class="section-box">
+                    <select class="attendance-select"
+                            th:attr="data-enrollment-id=${student.enrollmentId},data-section-id=${sectionAttendance.sectionId}"
+                            th:data-current-status="${sectionAttendance.status}"
+                            th:classappend="${sectionAttendance.status == 'PRESENT'} ? ' status-present' :
+                                            (${sectionAttendance.status == 'LATE'} ? ' status-late' :
+                                            (${sectionAttendance.status == 'ABSENT'} ? ' status-absent' :
+                                            (${sectionAttendance.status == 'NOT_OPEN'} ? ' status-not-open' : ' status-unchecked'))}">
+                        <option value="" th:selected="${sectionAttendance.status == 'UNCHECKED'}">미체크</option>
+                        <option value="" th:selected="${sectionAttendance.status == 'NOT_OPEN'}">오픈 전</option>
+                        <option value="PRESENT" th:selected="${sectionAttendance.status == 'PRESENT'}">출석</option>
+                        <option value="LATE" th:selected="${sectionAttendance.status == 'LATE'}">지각</option>
+                        <option value="ABSENT" th:selected="${sectionAttendance.status == 'ABSENT'}">결석</option>
+                    </select>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="table-wrapper" th:if="${studentList == null or #lists.isEmpty(studentList)}">
+        <div class="empty-message">수강 중인 학생이 없습니다.</div>
+    </div>
+</div>
+
+<script>
+    (function () {
+        const saveMessage = document.getElementById("saveMessage");
+        const selects = document.querySelectorAll(".attendance-select");
+
+        function applyStatusClass(select, status) {
+            select.classList.remove("status-present", "status-late", "status-absent", "status-unchecked", "status-not-open");
+
+            if (status === "PRESENT") {
+                select.classList.add("status-present");
+                return;
+            }
+
+            if (status === "LATE") {
+                select.classList.add("status-late");
+                return;
+            }
+
+            if (status === "ABSENT") {
+                select.classList.add("status-absent");
+                return;
+            }
+
+            if (status === "NOT_OPEN") {
+                select.classList.add("status-not-open");
+                return;
+            }
+
+            select.classList.add("status-unchecked");
+        }
+
+        selects.forEach(function (select) {
+            select.addEventListener("change", async function () {
+                const enrollmentId = select.dataset.enrollmentId;
+                const sectionId = select.dataset.sectionId;
+                const status = select.value;
+                const previousStatus = select.dataset.currentStatus || "";
+
+                applyStatusClass(select, status === "" ? "UNCHECKED" : status);
+
+                if (status === "") {
+                    select.dataset.currentStatus = "";
+                    saveMessage.textContent = "미체크 상태는 화면 표시용이며 저장하지 않았다.";
+                    saveMessage.classList.remove("error");
+                    return;
+                }
+
+                try {
+                    const response = await fetch("/instructor/grades/manage/attendance", {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+                        },
+                        body: new URLSearchParams({
+                            enrollmentId: enrollmentId,
+                            sectionId: sectionId,
+                            status: status
+                        })
+                    });
+
+                    if (!response.ok) {
+                        throw new Error("save failed");
+                    }
+
+                    select.dataset.currentStatus = status;
+                    saveMessage.textContent = "출결 상태를 저장했다.";
+                    saveMessage.classList.remove("error");
+                } catch (error) {
+                    select.value = previousStatus;
+                    applyStatusClass(select, previousStatus === "" ? "UNCHECKED" : previousStatus);
+                    saveMessage.textContent = "출결 저장에 실패했다.";
+                    saveMessage.classList.add("error");
+                }
+            });
+        });
+    })();
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/instructor/grade/manage.html
+++ b/src/main/resources/templates/instructor/grade/manage.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>학생 명단 및 관리</title>
+    <style>
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: Arial, sans-serif;
+            background-color: #f4f6f8;
+            color: #222;
+        }
+
+        .page-wrapper {
+            max-width: 1600px;
+            margin: 0 auto;
+            padding: 32px 24px 48px;
+        }
+
+        .page-title {
+            margin: 0 0 8px;
+            font-size: 32px;
+        }
+
+        .page-desc {
+            margin: 0 0 24px;
+            color: #666;
+        }
+
+        .top-bar {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        .course-badge {
+            display: inline-block;
+            padding: 8px 14px;
+            border-radius: 999px;
+            background-color: #e8f0ff;
+            color: #1d4ed8;
+            font-weight: bold;
+        }
+
+        .table-wrapper {
+            overflow-x: auto;
+            background-color: #fff;
+            border: 1px solid #ddd;
+            border-radius: 12px;
+            padding: 16px;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            min-width: 1350px;
+        }
+
+        th, td {
+            border: 1px solid #e1e1e1;
+            padding: 12px;
+            text-align: center;
+            vertical-align: middle;
+        }
+
+        th {
+            background-color: #f8fafc;
+            font-size: 14px;
+            white-space: nowrap;
+        }
+
+        td {
+            background-color: #fff;
+            font-size: 14px;
+        }
+
+        .student-col {
+            min-width: 120px;
+            font-weight: bold;
+        }
+
+        .email-col {
+            min-width: 200px;
+        }
+
+        .summary-col {
+            min-width: 180px;
+        }
+
+        .score-col {
+            min-width: 100px;
+        }
+
+        .section-box {
+            min-width: 150px;
+        }
+
+        .attendance-select {
+            width: 100%;
+            min-width: 120px;
+            padding: 8px 10px;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font-size: 13px;
+            font-weight: bold;
+        }
+
+        .status-present {
+            background-color: #e8f7ec;
+            color: #166534;
+        }
+
+        .status-late {
+            background-color: #fff7db;
+            color: #a16207;
+        }
+
+        .status-absent {
+            background-color: #fdecec;
+            color: #b91c1c;
+        }
+
+        .empty-message {
+            padding: 24px;
+            text-align: center;
+            color: #666;
+        }
+    </style>
+</head>
+<body>
+<div class="page-wrapper">
+    <div class="top-bar">
+        <div>
+            <h1 class="page-title">학생 명단 및 관리</h1>
+            <p class="page-desc">한 화면에서 학생 성적과 섹션별 출결 상태를 확인할 수 있다.</p>
+        </div>
+        <div class="course-badge" th:text="|코스 ID: ${courseId}|">코스 ID: 1</div>
+    </div>
+
+    <div class="table-wrapper" th:if="${studentList != null and !#lists.isEmpty(studentList)}">
+        <table>
+            <thead>
+            <tr>
+                <th class="student-col">학생 이름</th>
+                <th class="email-col">이메일</th>
+                <th>진도율</th>
+                <th class="summary-col">출결 요약</th>
+                <th class="score-col">과제 점수</th>
+                <th class="score-col">시험 점수</th>
+                <th class="score-col">태도 점수</th>
+                <th th:each="section : ${studentList[0].sectionAttendanceList}"
+                    class="section-box"
+                    th:text="${section.sectionTitle}">
+                    섹션명
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="student : ${studentList}">
+                <td class="student-col" th:text="${student.studentName}">김학생</td>
+                <td class="email-col" th:text="${student.email}">student@test.com</td>
+                <td th:text="|${student.progressRate}%|">50%</td>
+                <td class="summary-col" th:text="${student.attendanceSummary}">출석 3 / 지각 1 / 결석 0</td>
+                <td class="score-col" th:text="${student.assignmentScore}">95.0</td>
+                <td class="score-col" th:text="${student.examScore}">88.0</td>
+                <td class="score-col" th:text="${student.attitudeScore}">92.0</td>
+                <td th:each="sectionAttendance : ${student.sectionAttendanceList}" class="section-box">
+                    <select class="attendance-select"
+                            th:classappend="${sectionAttendance.status == 'PRESENT'} ? ' status-present' :
+                                            (${sectionAttendance.status == 'LATE'} ? ' status-late' : ' status-absent')">
+                        <option value="PRESENT" th:selected="${sectionAttendance.status == 'PRESENT'}">출석</option>
+                        <option value="LATE" th:selected="${sectionAttendance.status == 'LATE'}">지각</option>
+                        <option value="ABSENT" th:selected="${sectionAttendance.status == 'ABSENT'}">결석</option>
+                    </select>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="table-wrapper" th:if="${studentList == null or #lists.isEmpty(studentList)}">
+        <div class="empty-message">수강 중인 학생이 없습니다.</div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/instructor/grade/managepage.html
+++ b/src/main/resources/templates/instructor/grade/managepage.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>학생 명단 및 관리</title>
+    <style>
+        * { box-sizing: border-box; }
+        body { margin: 0; font-family: Arial, sans-serif; background-color: #f4f6f8; color: #222; }
+        .page-wrapper { max-width: 1600px; margin: 0 auto; padding: 32px 24px 48px; }
+        .top-bar { display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 20px; flex-wrap: wrap; }
+        .title-group h1 { margin: 0 0 8px; font-size: 32px; }
+        .title-group p { margin: 0; color: #666; }
+        .top-actions { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+        .course-badge { display: inline-block; padding: 8px 14px; border-radius: 999px; background-color: #e8f0ff; color: #1d4ed8; font-weight: bold; }
+        .back-link { display: inline-block; padding: 10px 14px; border-radius: 10px; background-color: #334155; color: #fff; text-decoration: none; font-weight: bold; }
+        .table-wrapper { overflow-x: auto; background-color: #fff; border: 1px solid #ddd; border-radius: 12px; padding: 16px; }
+        table { width: 100%; border-collapse: collapse; min-width: 1450px; }
+        th, td { border: 1px solid #e1e1e1; padding: 12px; text-align: center; vertical-align: middle; }
+        th { background-color: #f8fafc; font-size: 14px; white-space: nowrap; }
+        td { background-color: #fff; font-size: 14px; }
+        .student-col { min-width: 120px; font-weight: bold; }
+        .email-col { min-width: 200px; }
+        .summary-col { min-width: 180px; }
+        .score-col { min-width: 100px; }
+        .section-box { min-width: 150px; }
+        .attendance-select { width: 100%; min-width: 120px; padding: 8px 10px; border: 1px solid #ccc; border-radius: 6px; font-size: 13px; font-weight: bold; background-color: #fff; }
+        .status-present { background-color: #e8f7ec; color: #166534; }
+        .status-late { background-color: #fff7db; color: #a16207; }
+        .status-absent { background-color: #fdecec; color: #b91c1c; }
+        .status-unchecked { background-color: #eef2f7; color: #475569; }
+        .status-not-open { background-color: #f1f5f9; color: #64748b; }
+        .save-message { min-height: 22px; margin: 0 0 16px; font-weight: bold; color: #0f766e; }
+        .save-message.error { color: #b91c1c; }
+        .empty-message { padding: 24px; text-align: center; color: #666; }
+    </style>
+</head>
+<body>
+<div class="page-wrapper">
+    <div class="top-bar">
+        <div class="title-group">
+            <h1>학생 명단 및 관리</h1>
+            <p>한 화면에서 학생 성적과 섹션별 출결 상태를 함께 관리할 수 있다.</p>
+        </div>
+        <div class="top-actions">
+            <div class="course-badge" th:text="|코스 ID: ${courseId}|">코스 ID: 1</div>
+            <a class="back-link" th:href="@{/instructor/grades}">성적 목록으로 돌아가기</a>
+        </div>
+    </div>
+
+    <p class="save-message" id="saveMessage"></p>
+
+    <div class="table-wrapper" th:if="${studentList != null and !#lists.isEmpty(studentList)}">
+        <table>
+            <thead>
+            <tr>
+                <th class="student-col">학생 이름</th>
+                <th class="email-col">이메일</th>
+                <th>진도율</th>
+                <th class="summary-col">출결 요약</th>
+                <th class="score-col">과제 점수</th>
+                <th class="score-col">시험 점수</th>
+                <th class="score-col">태도 점수</th>
+                <th th:each="section : ${studentList[0].sectionAttendanceList}"
+                    class="section-box"
+                    th:text="${section.sectionTitle}">
+                    섹션명
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="student : ${studentList}">
+                <td class="student-col" th:text="${student.studentName}">김학생</td>
+                <td class="email-col" th:text="${student.email}">student@test.com</td>
+                <td th:text="|${student.progressRate}%|">50%</td>
+                <td class="summary-col" th:text="${student.attendanceSummary}">출석 3 / 지각 1 / 결석 0</td>
+                <td class="score-col" th:text="${student.assignmentScore}">95.0</td>
+                <td class="score-col" th:text="${student.examScore}">88.0</td>
+                <td class="score-col" th:text="${student.attitudeScore}">92.0</td>
+                <td th:each="sectionAttendance : ${student.sectionAttendanceList}" class="section-box">
+                    <select class="attendance-select"
+                            th:attr="data-enrollment-id=${student.enrollmentId},data-section-id=${sectionAttendance.sectionId}"
+                            th:data-current-status="${sectionAttendance.status}"
+                            th:classappend="${sectionAttendance.status == 'PRESENT' ? ' status-present' :
+                                            (sectionAttendance.status == 'LATE' ? ' status-late' :
+                                            (sectionAttendance.status == 'ABSENT' ? ' status-absent' :
+                                            (sectionAttendance.status == 'NOT_OPEN' ? ' status-not-open' : ' status-unchecked')))}">
+                        <option value="" th:selected="${sectionAttendance.status == 'UNCHECKED'}">미체크</option>
+                        <option value="" th:selected="${sectionAttendance.status == 'NOT_OPEN'}">오픈 전</option>
+                        <option value="PRESENT" th:selected="${sectionAttendance.status == 'PRESENT'}">출석</option>
+                        <option value="LATE" th:selected="${sectionAttendance.status == 'LATE'}">지각</option>
+                        <option value="ABSENT" th:selected="${sectionAttendance.status == 'ABSENT'}">결석</option>
+                    </select>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <div class="table-wrapper" th:if="${studentList == null or #lists.isEmpty(studentList)}">
+        <div class="empty-message">수강 중인 학생이 없습니다.</div>
+    </div>
+</div>
+
+<script>
+    (function () {
+        const saveMessage = document.getElementById("saveMessage");
+        const selects = document.querySelectorAll(".attendance-select");
+
+        function applyStatusClass(select, status) {
+            select.classList.remove("status-present", "status-late", "status-absent", "status-unchecked", "status-not-open");
+
+            if (status === "PRESENT") { select.classList.add("status-present"); return; }
+            if (status === "LATE") { select.classList.add("status-late"); return; }
+            if (status === "ABSENT") { select.classList.add("status-absent"); return; }
+            if (status === "NOT_OPEN") { select.classList.add("status-not-open"); return; }
+            select.classList.add("status-unchecked");
+        }
+
+        selects.forEach(function (select) {
+            select.addEventListener("change", async function () {
+                const enrollmentId = select.dataset.enrollmentId;
+                const sectionId = select.dataset.sectionId;
+                const status = select.value;
+                const previousStatus = select.dataset.currentStatus || "";
+
+                applyStatusClass(select, status === "" ? "UNCHECKED" : status);
+
+                if (status === "") {
+                    select.dataset.currentStatus = "";
+                    saveMessage.textContent = "미체크 상태는 화면 표시용이며 저장하지 않았다.";
+                    saveMessage.classList.remove("error");
+                    return;
+                }
+
+                try {
+                    const response = await fetch("/instructor/grades/manage/attendance", {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8"
+                        },
+                        body: new URLSearchParams({
+                            enrollmentId: enrollmentId,
+                            sectionId: sectionId,
+                            status: status
+                        })
+                    });
+
+                    if (!response.ok) {
+                        throw new Error("save failed");
+                    }
+
+                    select.dataset.currentStatus = status;
+                    saveMessage.textContent = "출결 상태를 저장했다.";
+                    saveMessage.classList.remove("error");
+                } catch (error) {
+                    select.value = previousStatus;
+                    applyStatusClass(select, previousStatus === "" ? "UNCHECKED" : previousStatus);
+                    saveMessage.textContent = "출결 저장에 실패했다.";
+                    saveMessage.classList.add("error");
+                }
+            });
+        });
+    })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당하는 항목에 체크하세요 -->
- [x] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 🔗 관련 이슈
Closes #90 

---

## 🛠️ 작업 내용
- 강사용 성적 목록 화면에서 코스별 학생 관리 화면으로 이동할 수 있는 임시 버튼을 추가했다.
- 강사용 학생 관리 화면에서 학생별 섹션 출결 상태를 한 화면에서 볼 수 있도록 구현했다.
- 강사가 출결 상태를 변경하면 비동기로 저장되도록 출결 수정 API와 `fetch`를 연결했다.

---

## 🔄 변경 사항
- `GradeDTO`, `GradeService`, 강사용 성적 목록 템플릿을 수정해 `courseId`를 넘기고 관리 화면으로 진입할 수 있도록 변경했다.
- `InstructorGradeService`, `InstructorGradeManageController`를 통해 코스별 학생 목록과 섹션별 출결 상태를 조회하고 수정할 수 있도록 구현했다.
- 출결 상태를 `출석`, `지각`, `결석`, `미체크`, `오픈 전`으로 구분해 표시하도록 화면과 서비스 로직을 보완했다.


---

## ✅ 체크리스트
- [x] 팀 코딩 컨벤션을 준수했습니다.
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 불필요한 코드는 제거했습니다.
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우).