### PR TITLE
[UPDATE] 게시판 목록/상세 UI 개선 및 댓글·답글 사용성 수정

### DIFF
--- a/src/main/java/com/wanted/projectmodule2lms/domain/board/controller/BoardController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/board/controller/BoardController.java
@@ -1,5 +1,4 @@
 package com.wanted.projectmodule2lms.domain.board.controller;
-
 import com.wanted.projectmodule2lms.domain.board.model.dto.BoardDTO;
 import com.wanted.projectmodule2lms.domain.board.model.entity.BoardType;
 import com.wanted.projectmodule2lms.domain.board.model.service.BoardService;
@@ -15,11 +14,7 @@ import com.wanted.projectmodule2lms.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
@@ -28,7 +23,6 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/board")
 public class BoardController {
-
     private final CommentService commentService;
     private final BoardService boardService;
     private final MemberRepository memberRepository;
@@ -111,13 +105,19 @@ public class BoardController {
 
     @GetMapping("/detail")
     public String boardDetailPage(@RequestParam Integer postId, Model model) {
-        boardService.increaseViewCount(postId);
         BoardDTO board = boardService.findBoardById(postId);
         List<CommentDTO> commentList=commentService.findCommentsByPostId(postId);
         model.addAttribute("board", board);
         model.addAttribute("commentList", commentList);
         model.addAttribute("listPath", getListPath(board.getPostType(), board.getCourseId()));
         return "board/detail";
+    }
+
+    @PostMapping("/view-count")
+    @ResponseBody
+    public void viewCount(@LoginMemberId Long loginMemberId,
+                          @RequestParam Integer postId) {
+        boardService.increaseViewCount(postId);
     }
 
     @GetMapping("/regist")

--- a/src/main/java/com/wanted/projectmodule2lms/domain/certificate/controller/CertificateController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/certificate/controller/CertificateController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -26,7 +27,7 @@ public class CertificateController {
     private final SectionRepository sectionRepository;
 
 
-    @GetMapping("/request")
+    @PostMapping("/request")
     public String requestCertificate(@LoginMemberId Long memberId,
                                      @RequestParam Integer courseId) {
         if (memberId == null) {

--- a/src/main/resources/static/css/board/crud.css
+++ b/src/main/resources/static/css/board/crud.css
@@ -1,71 +1,204 @@
-﻿* {
+* {
     box-sizing: border-box;
 }
 
 body {
     margin: 0;
-    font-family: Arial, sans-serif;
-    background-color: #f7f7f7;
-    color: #222;
+    font-family: "Segoe UI", Arial, sans-serif;
+    background: linear-gradient(180deg, #f4f7fb 0%, #eef3f9 100%);
+    color: #182033;
+}
+
+a {
+    color: inherit;
 }
 
 .page-wrapper {
-    width: 960px;
+    width: min(1180px, calc(100% - 32px));
     margin: 0 auto;
-    padding: 40px 20px 60px;
+    padding: 36px 0 64px;
+}
+
+.top-utility {
+    display: flex;
+    justify-content: space-between;
+    align-items: stretch;
+    gap: 20px;
+    margin-bottom: 24px;
+    flex-wrap: wrap;
+}
+
+.page-main {
+    flex: 1;
+    min-width: 0;
 }
 
 .page-title {
-    margin: 0 0 10px;
-    font-size: 30px;
+    margin: 0 0 12px;
+    font-size: 2.5rem;
+    font-weight: 800;
+    letter-spacing: -0.05em;
 }
 
 .page-desc {
-    margin: 0 0 24px;
-    color: #666;
+    margin: 0;
+    color: #5f6b83;
+    font-size: 1rem;
+    line-height: 1.7;
+}
+
+.page-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+    padding: 8px 14px;
+    border-radius: 999px;
+    background: #e8efff;
+    color: #2048b8;
+    font-size: 0.82rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .box {
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid #dde5f0;
+    border-radius: 28px;
+    padding: 28px;
+    margin-bottom: 22px;
+    box-shadow: 0 20px 48px rgba(31, 45, 83, 0.08);
+}
+
+.section-title {
+    margin: 0 0 18px;
+    font-size: 1.5rem;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+}
+
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.feature-card {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    border-radius: 24px;
+    border: 1px solid #e2e9f4;
+    background: linear-gradient(180deg, #ffffff 0%, #f9fbff 100%);
     padding: 24px;
-    margin-bottom: 20px;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.feature-card:hover {
+    transform: translateY(-4px);
+    border-color: #bfd1f8;
+    box-shadow: 0 16px 32px rgba(37, 99, 235, 0.12);
+}
+
+.feature-card h3 {
+    margin: 0 0 12px;
+    font-size: 1.2rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+}
+
+.feature-card p {
+    margin: 0;
+    color: #607089;
+    line-height: 1.7;
+}
+
+.feature-card .card-tag {
+    display: inline-flex;
+    margin-bottom: 14px;
+    padding: 6px 11px;
+    border-radius: 999px;
+    background: #edf3ff;
+    color: #2750c4;
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
 }
 
 .table {
     width: 100%;
     border-collapse: collapse;
+    overflow: hidden;
 }
 
 .table th,
 .table td {
-    border: 1px solid #ddd;
-    padding: 12px;
+    padding: 15px 16px;
     text-align: left;
+    border-bottom: 1px solid #e6edf7;
 }
 
 .table th {
-    background-color: #f0f0f0;
+    background: #f7f9fd;
+    color: #4f5c74;
+    font-size: 0.92rem;
+    font-weight: 800;
+    white-space: nowrap;
 }
 
+.table tbody tr:hover {
+    background: #fafcff;
+}
+
+.post-row {
+    cursor: pointer;
+}
+
+.is-hidden {
+    display: none;
+}
+
+.reply-form-row td {
+    background: #f8fbff;
+}
+
+
 .form-row {
-    margin-bottom: 16px;
+    margin-bottom: 18px;
 }
 
 .form-row label {
     display: block;
     margin-bottom: 8px;
-    font-weight: bold;
+    font-weight: 700;
+    color: #2d3748;
 }
 
 .form-row input,
 .form-row select,
-.form-row textarea {
+.form-row textarea,
+.search-bar input,
+.search-bar select {
     width: 100%;
-    padding: 10px 12px;
-    border: 1px solid #ccc;
-    border-radius: 6px;
+    padding: 12px 14px;
+    border: 1px solid #d4dce8;
+    border-radius: 14px;
+    background: #fff;
+    font-size: 0.96rem;
+    color: #182033;
+    outline: none;
+    transition: border-color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.form-row input:focus,
+.form-row select:focus,
+.form-row textarea:focus,
+.search-bar input:focus,
+.search-bar select:focus {
+    border-color: #7aa2ff;
+    box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.18);
 }
 
 .form-row textarea {
@@ -81,23 +214,36 @@ body {
 }
 
 .btn {
-    display: inline-block;
-    padding: 10px 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 11px 18px;
     border: none;
-    border-radius: 6px;
-    background-color: #2f5bea;
-    color: white;
+    border-radius: 999px;
+    background: #2750c4;
+    color: #ffffff;
     text-decoration: none;
     cursor: pointer;
-    font-size: 14px;
+    font-size: 0.95rem;
+    font-weight: 800;
+    box-shadow: 0 10px 20px rgba(39, 80, 196, 0.18);
+    transition: transform 0.16s ease, opacity 0.16s ease, box-shadow 0.16s ease;
+}
+
+.btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 24px rgba(39, 80, 196, 0.22);
 }
 
 .btn.gray {
-    background-color: #666;
+    background: #5f6c82;
+    box-shadow: 0 10px 20px rgba(95, 108, 130, 0.18);
 }
 
 .btn.red {
-    background-color: #c0392b;
+    background: #c0392b;
+    box-shadow: 0 10px 20px rgba(192, 57, 43, 0.18);
 }
 
 .search-bar {
@@ -105,66 +251,27 @@ body {
     gap: 10px;
     align-items: center;
     flex-wrap: wrap;
-    margin-bottom: 20px;
+    margin-bottom: 18px;
 }
 
-.search-bar input,
-.search-bar select {
-    padding: 10px 12px;
-    border: 1px solid #ccc;
-    border-radius: 6px;
+.search-bar input {
+    flex: 1;
+    min-width: 240px;
 }
 
 .meta {
-    color: #666;
-    margin-bottom: 16px;
+    color: #64748b;
+    margin-bottom: 18px;
+    font-size: 0.94rem;
 }
 
 .content-box {
     min-height: 160px;
-    padding: 16px;
-    border: 1px solid #e5e5e5;
-    background-color: #fafafa;
-    border-radius: 6px;
-    line-height: 1.6;
-}
-
-.section-title {
-    margin: 0 0 14px;
-    font-size: 22px;
-}
-
-.card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 16px;
-}
-
-.feature-card {
-    display: block;
-    text-decoration: none;
-    color: inherit;
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 10px;
-    padding: 20px;
-    transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-.feature-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.08);
-}
-
-.feature-card h3 {
-    margin: 0 0 10px;
-    font-size: 18px;
-}
-
-.feature-card p {
-    margin: 0;
-    color: #666;
-    line-height: 1.6;
+    padding: 18px;
+    border: 1px solid #e6edf7;
+    background-color: #f9fbfe;
+    border-radius: 18px;
+    line-height: 1.8;
 }
 
 .link-list {
@@ -174,27 +281,20 @@ body {
     margin-top: 14px;
 }
 
-.top-utility {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 16px;
-    margin-bottom: 20px;
-    flex-wrap: wrap;
-}
-
 .role-panel {
-    width: 260px;
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 10px;
-    padding: 16px;
+    width: 280px;
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid #dde5f0;
+    border-radius: 24px;
+    padding: 18px;
+    box-shadow: 0 16px 38px rgba(31, 45, 83, 0.08);
 }
 
 .role-label {
-    margin: 0 0 10px;
-    font-size: 14px;
-    color: #666;
+    margin: 0 0 12px;
+    font-size: 0.9rem;
+    color: #64748b;
+    font-weight: 700;
 }
 
 .role-buttons {
@@ -204,57 +304,45 @@ body {
 }
 
 .role-btn {
-    border: 1px solid #cbd5e1;
-    background-color: #fff;
+    border: 1px solid #cfd9e8;
+    background: #fff;
     border-radius: 999px;
-    padding: 8px 14px;
+    padding: 9px 14px;
     cursor: pointer;
-    font-weight: 700;
+    font-weight: 800;
+    color: #344054;
 }
 
 .role-btn.active {
-    background-color: #2f5bea;
+    background: #2750c4;
     color: #fff;
-    border-color: #2f5bea;
+    border-color: #2750c4;
 }
 
 .role-current {
-    margin-top: 12px;
-    font-size: 14px;
-    color: #444;
+    margin-top: 14px;
+    font-size: 0.92rem;
+    color: #475569;
+    line-height: 1.6;
 }
 
-.role-badge {
-    display: inline-block;
-    margin-left: 6px;
-    padding: 4px 10px;
+.role-badge,
+.context-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 5px 10px;
     border-radius: 999px;
-    background: #e8efff;
+    background: #edf3ff;
     color: #1d4ed8;
-    font-weight: 700;
-    font-size: 12px;
-}
-
-.page-main {
-    flex: 1;
-    min-width: 0;
+    font-weight: 800;
+    font-size: 0.78rem;
 }
 
 .permission-note {
-    margin-top: 10px;
-    color: #666;
-    font-size: 14px;
-    line-height: 1.5;
-}
-
-.context-badge {
-    display: inline-block;
-    padding: 6px 12px;
-    background: #eef4ff;
-    color: #1d4ed8;
-    border-radius: 999px;
-    font-weight: 700;
-    font-size: 13px;
+    margin-top: 12px;
+    color: #64748b;
+    font-size: 0.9rem;
+    line-height: 1.65;
 }
 
 .blurred-secret {
@@ -285,4 +373,19 @@ body {
 [data-board-action].is-hidden,
 [data-comment-action].is-hidden {
     display: none !important;
+}
+
+@media (max-width: 960px) {
+    .page-wrapper {
+        width: min(100% - 24px, 100%);
+        padding: 24px 0 48px;
+    }
+
+    .top-utility {
+        flex-direction: column;
+    }
+
+    .role-panel {
+        width: 100%;
+    }
 }

--- a/src/main/resources/static/js/board/post-row.js
+++ b/src/main/resources/static/js/board/post-row.js
@@ -1,0 +1,16 @@
+(function () {
+    document.addEventListener("DOMContentLoaded", function () {
+        document.querySelectorAll(".post-row").forEach(function (row) {
+            row.addEventListener("click", function (event) {
+                if (event.target.closest("a, button, input, select, textarea, label")) {
+                    return;
+                }
+
+                const href = row.dataset.href;
+                if (href) {
+                    window.location.href = href;
+                }
+            });
+        });
+    });
+})();

--- a/src/main/resources/templates/board/admin-notice-list.html
+++ b/src/main/resources/templates/board/admin-notice-list.html
@@ -2,42 +2,52 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>관리자 공지 목록</title>
+    <title>관리자 공지사항 목록</title>
     <link rel="stylesheet" href="/css/board/crud.css">
 </head>
 <body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId}">
 <div class="page-wrapper">
     <div class="top-utility">
         <div class="role-panel">
-            <p class="role-label">현재 역할 전환</p>
+            <p class="role-label">현재 로그인 정보</p>
             <div class="role-buttons">
                 <button class="role-btn" data-role="ADMIN" type="button">관리자</button>
                 <button class="role-btn" data-role="INSTRUCTOR" type="button">강사</button>
                 <button class="role-btn" data-role="STUDENT" type="button">학생</button>
             </div>
-            <div class="role-current">현재 로그인: <span class="role-badge" data-current-role th:text="${currentRole}">STUDENT</span> / 사용자 ID: <span class="role-badge" data-current-member-id th:text="${currentMemberId}">1</span></div>
-            <p class="permission-note">관리자 공지는 관리자 본인 글만 수정, 삭제할 수 있습니다.</p>
+            <div class="role-current">
+                현재 역할:
+                <span class="role-badge" data-current-role th:text="${currentRole}">ADMIN</span>
+                / 회원 ID:
+                <span class="role-badge" data-current-member-id th:text="${currentMemberId}">1</span>
+            </div>
+            <p class="permission-note">관리자 공지사항은 관리자만 작성할 수 있습니다.</p>
         </div>
         <div class="page-main">
-            <h1 class="page-title">관리자 공지 목록</h1>
-            <p class="page-desc">관리자가 작성하고 전체 사용자가 조회할 수 있는 공지 게시판입니다.</p>
+            <div class="page-eyebrow">Admin Notice</div>
+            <h1 class="page-title">관리자 공지사항</h1>
+            <p class="page-desc">운영 공지와 시스템 안내를 빠르게 확인할 수 있는 관리자 전용 게시판입니다.</p>
         </div>
     </div>
 
     <div class="box">
         <div class="button-group">
             <a class="btn" href="/board/regist?type=ADMIN_NOTICE" data-role-only="ADMIN">공지 등록</a>
-            <a class="btn gray" href="/board/list">게시판 메인</a>
+            <a class="btn gray" href="/board/list">게시판 홈</a>
         </div>
     </div>
 
     <div class="box">
         <form class="search-bar" method="get" action="/board/admin-notices">
-            <input type="text" name="keyword" placeholder="관리자 공지 제목 검색" th:value="${keyword}">
+            <input type="text" name="keyword" placeholder="검색어를 입력하세요" th:value="${keyword}">
             <button type="submit" class="btn">검색</button>
             <a class="btn gray" href="/board/admin-notices">초기화</a>
         </form>
-        <p class="meta">검색어: <span th:text="${keyword != null and !keyword.isBlank() ? keyword : '전체'}">전체</span></p>
+        <p class="meta">
+            검색 기준:
+            <span th:if="${keyword != null and !keyword.isBlank()}" th:text="${keyword}">keyword</span>
+            <span th:unless="${keyword != null and !keyword.isBlank()}">전체</span>
+        </p>
 
         <table class="table">
             <thead>
@@ -49,38 +59,38 @@
             </tr>
             </thead>
             <tbody>
-            <tr th:each="board, stat : ${boardList}">
+            <tr th:each="board, stat : ${boardList}"
+                class="post-row"
+                th:attr="data-href=@{/board/detail(postId=${board.postId})}">
                 <td th:text="${stat.count}">1</td>
-                <td><a th:href="@{/board/detail(postId=${board.postId})}" th:text="${board.title}">공지 제목</a></td>
-
+                <td>
+                    <a th:href="@{/board/detail(postId=${board.postId})}" th:text="${board.title}">관리자 공지 제목</a>
+                </td>
                 <td>
                     <div th:with="writer=${@memberRepository.findById(board.memberId).orElse(null)}"
                          style="display: inline-flex; align-items: center; gap: 8px;">
-
                         <img th:if="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
                              th:src="@{|/uploads/${writer.profile.profileImage}|}"
                              onerror="this.src='/img/default-profile.png'"
-                             alt="프로필"
+                             alt="profile image"
                              style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
-
                         <img th:unless="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
                              src="/img/default-profile.png"
-                             alt="기본프로필"
+                             alt="default profile image"
                              style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
-
                         <span th:text="${board.memberName != null ? board.memberName : board.memberId}">관리자1</span>
                     </div>
                 </td>
-
                 <td th:text="${board.viewCount}">120</td>
             </tr>
             <tr th:if="${boardList == null or #lists.isEmpty(boardList)}">
-                <td colspan="4">조회된 공지가 없습니다.</td>
+                <td colspan="4">등록된 관리자 공지사항이 없습니다.</td>
             </tr>
             </tbody>
         </table>
     </div>
 </div>
 <script src="/js/board/role-switcher.js"></script>
+<script src="/js/board/post-row.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/board/course-notice-list.html
+++ b/src/main/resources/templates/board/course-notice-list.html
@@ -2,86 +2,97 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>코스 공지 목록</title>
+    <title>코스 공지사항 목록</title>
     <link rel="stylesheet" href="/css/board/crud.css">
 </head>
 <body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId}">
 <div class="page-wrapper">
     <div class="top-utility">
         <div class="role-panel">
-            <p class="role-label">현재 역할 전환</p>
+            <p class="role-label">현재 로그인 정보</p>
             <div class="role-buttons">
                 <button class="role-btn" data-role="ADMIN" type="button">관리자</button>
                 <button class="role-btn" data-role="INSTRUCTOR" type="button">강사</button>
                 <button class="role-btn" data-role="STUDENT" type="button">학생</button>
             </div>
-            <div class="role-current">현재 로그인: <span class="role-badge" data-current-role th:text="${currentRole}">STUDENT</span> / 사용자 ID: <span class="role-badge" data-current-member-id th:text="${currentMemberId}">1</span></div>
-            <p class="permission-note">코스 공지는 강사 본인이 작성한 글만 수정, 삭제할 수 있습니다.</p>
+            <div class="role-current">
+                현재 역할:
+                <span class="role-badge" data-current-role th:text="${currentRole}">INSTRUCTOR</span>
+                / 회원 ID:
+                <span class="role-badge" data-current-member-id th:text="${currentMemberId}">1</span>
+            </div>
+            <p class="permission-note">코스 공지사항은 강사가 코스 수강생에게 안내할 때 사용합니다.</p>
         </div>
         <div class="page-main">
-            <h1 class="page-title">코스 공지 목록</h1>
-            <p class="page-desc">강사가 코스 단위로 작성하는 공지 게시판입니다.</p>
+            <div class="page-eyebrow">Course Notice</div>
+            <h1 class="page-title">코스 공지사항</h1>
+            <p class="page-desc">강의별 공지와 학습 안내를 한곳에서 확인할 수 있는 코스 게시판입니다.</p>
         </div>
     </div>
 
     <div class="box">
         <div class="button-group">
             <a class="btn" href="/board/regist?type=COURSE_NOTICE" data-role-only="INSTRUCTOR">공지 등록</a>
-            <a class="btn gray" href="/board/list">게시판 메인</a>
+            <a class="btn gray" href="/board/list">게시판 홈</a>
         </div>
     </div>
 
     <div class="box">
         <form class="search-bar" method="get" action="/board/course-notices">
-            <input type="text" name="keyword" placeholder="코스 공지 제목 검색" th:value="${keyword}">
+            <input type="text" name="keyword" placeholder="검색어를 입력하세요" th:value="${keyword}">
             <button type="submit" class="btn">검색</button>
             <a class="btn gray" href="/board/course-notices">초기화</a>
         </form>
-        <p class="meta">검색어: <span th:text="${keyword != null and !keyword.isBlank() ? keyword : '전체'}">전체</span></p>
+        <p class="meta">
+            검색 기준:
+            <span th:if="${keyword != null and !keyword.isBlank()}" th:text="${keyword}">keyword</span>
+            <span th:unless="${keyword != null and !keyword.isBlank()}">전체</span>
+        </p>
 
         <table class="table">
             <thead>
             <tr>
                 <th>번호</th>
-                <th>코스</th>
+                <th>코스명</th>
                 <th>제목</th>
                 <th>작성자</th>
                 <th>조회수</th>
             </tr>
             </thead>
             <tbody>
-            <tr th:each="board, stat : ${boardList}">
+            <tr th:each="board, stat : ${boardList}"
+                class="post-row"
+                th:attr="data-href=@{/board/detail(postId=${board.postId})}">
                 <td th:text="${stat.count}">1</td>
                 <td th:text="${board.courseTitle != null ? board.courseTitle : '-'}">Spring Boot 입문</td>
-                <td><a th:href="@{/board/detail(postId=${board.postId})}" th:text="${board.title}">코스 공지 제목</a></td>
-
+                <td>
+                    <a th:href="@{/board/detail(postId=${board.postId})}" th:text="${board.title}">코스 공지 제목</a>
+                </td>
                 <td>
                     <div th:with="writer=${@memberRepository.findById(board.memberId).orElse(null)}"
                          style="display: inline-flex; align-items: center; gap: 8px;">
-
                         <img th:if="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
                              th:src="@{|/uploads/${writer.profile.profileImage}|}"
                              onerror="this.src='/img/default-profile.png'"
-                             alt="프로필"
+                             alt="profile image"
                              style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
-
                         <img th:unless="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
                              src="/img/default-profile.png"
-                             alt="기본프로필"
+                             alt="default profile image"
                              style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
-
-                        <span th:text="${board.memberName != null ? board.memberName : board.memberId}">박강사</span>
+                        <span th:text="${board.memberName != null ? board.memberName : board.memberId}">강사1</span>
                     </div>
                 </td>
                 <td th:text="${board.viewCount}">95</td>
             </tr>
             <tr th:if="${boardList == null or #lists.isEmpty(boardList)}">
-                <td colspan="5">조회된 코스 공지가 없습니다.</td>
+                <td colspan="5">등록된 코스 공지사항이 없습니다.</td>
             </tr>
             </tbody>
         </table>
     </div>
 </div>
 <script src="/js/board/role-switcher.js"></script>
+<script src="/js/board/post-row.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/board/detail.html
+++ b/src/main/resources/templates/board/detail.html
@@ -2,45 +2,50 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>게시글 상세</title>
+    <title>게시글 상세 보기</title>
     <link rel="stylesheet" href="/css/board/crud.css">
 </head>
-<body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId}">
+<body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId},data-post-id=${board.postId}">
 <div class="page-wrapper">
     <div class="top-utility">
         <div class="role-panel">
-            <p class="role-label">현재 역할 전환</p>
+            <p class="role-label">현재 로그인 정보</p>
             <div class="role-buttons">
                 <button class="role-btn" data-role="ADMIN" type="button">관리자</button>
                 <button class="role-btn" data-role="INSTRUCTOR" type="button">강사</button>
                 <button class="role-btn" data-role="STUDENT" type="button">학생</button>
             </div>
-            <div class="role-current">현재 로그인: <span class="role-badge" data-current-role th:text="${currentRole}">STUDENT</span> / 사용자 ID: <span class="role-badge" data-current-member-id th:text="${currentMemberId}">1</span></div>
-            <p class="permission-note">비밀 Q&amp;A는 강사, 관리자, 작성자 학생만 내용이 그대로 보입니다.</p>
+            <div class="role-current">
+                현재 역할:
+                <span class="role-badge" data-current-role th:text="${currentRole}">STUDENT</span>
+                / 사용자 ID:
+                <span class="role-badge" data-current-member-id th:text="${currentMemberId}">1</span>
+            </div>
+            <p class="permission-note">비밀글 Q&amp;A는 강사, 관리자, 작성한 학생만 원문을 볼 수 있습니다.</p>
         </div>
         <div class="page-main">
             <h1 class="page-title">게시글 상세</h1>
-            <p class="page-desc">게시글 본문과 기본 정보를 확인하는 화면입니다.</p>
+            <p class="page-desc">게시글 본문과 댓글, 답글을 확인하는 화면입니다.</p>
         </div>
     </div>
 
     <div class="box">
         <div class="meta">
             게시글 번호: <span th:text="${board.postId}">1</span><br>
-            게시판 종류: <span th:text="${board.postType}">SECTION_QNA</span><br>
+            게시글 종류: <span th:text="${board.postType}">SECTION_QNA</span><br>
             작성자:
             <span th:with="writer=${@memberRepository.findById(board.memberId).orElse(null)}"
                   style="display: inline-flex; align-items: center; gap: 8px; vertical-align: middle;">
                 <img th:if="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
                      th:src="@{|/uploads/${writer.profile.profileImage}|}"
                      onerror="this.src='/img/default-profile.png'"
-                     alt="프로필"
+                     alt="profile image"
                      style="width: 24px; height: 24px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
                 <img th:unless="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
                      src="/img/default-profile.png"
-                     alt="기본프로필"
+                     alt="default profile image"
                      style="width: 24px; height: 24px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
-                <span th:text="${board.memberName != null ? board.memberName : board.memberId}">박강사</span>
+                <span th:text="${board.memberName != null ? board.memberName : board.memberId}">홍길동</span>
             </span><br>
             코스: <span th:text="${board.courseTitle != null ? board.courseTitle : '-'}">Spring Boot 입문</span><br>
             섹션 ID: <span th:text="${board.sectionId != null ? board.sectionId : '-'}">2</span><br>
@@ -75,6 +80,7 @@
             <a class="btn gray" th:href="${listPath}">목록으로</a>
         </div>
     </div>
+
     <div class="box">
         <h2>댓글</h2>
 
@@ -96,18 +102,51 @@
                             <img th:if="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
                                  th:src="@{|/uploads/${writer.profile.profileImage}|}"
                                  onerror="this.src='/img/default-profile.png'"
-                                 alt="프로필"
+                                 alt="profile image"
                                  style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
                             <img th:unless="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
                                  src="/img/default-profile.png"
-                                 alt="기본프로필"
+                                 alt="default profile image"
                                  style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
                             <span th:text="${comment.memberName != null ? comment.memberName : comment.memberId}">김학생</span>
                         </div>
                     </td>
                     <td th:text="${comment.content}">댓글 내용</td>
-                    <td th:text="${comment.createdAt}">2026-04-15</td>
+                    <td th:text="${#temporals.format(comment.createdAt, 'yyyy년 MM월 dd일 / HH:mm')}">2026년 04월 17일 / 09:43</td>
                     <td>
+                        <div class="button-group">
+                            <button type="button"
+                                    class="btn comment-edit-toggle-btn"
+                                    data-comment-action="manage"
+                                    th:attr="data-post-type=${board.postType},
+                                             data-author-id=${comment.memberId},
+                                             data-course-instructor-id=${board.courseInstructorId},
+                                             data-target=${'comment-edit-form-' + comment.commentId}"
+                                    >댓글 수정</button>
+                            <form method="post"
+                                  action="/comment/delete"
+                                  style="margin: 0;"
+                                  data-comment-action="manage"
+                                  th:attr="data-post-type=${board.postType},
+                                           data-author-id=${comment.memberId},
+                                           data-course-instructor-id=${board.courseInstructorId}">
+                                <input type="hidden" name="commentId" th:value="${comment.commentId}">
+                                <input type="hidden" name="postId" th:value="${board.postId}">
+                                <input type="hidden" name="currentMemberId" data-current-member-id-input>
+                                <input type="hidden" name="currentRole" data-current-role-input>
+                                <button type="submit"
+                                        class="btn red"
+                                        onclick="return confirm('정말 삭제하시겠습니까?');">댓글 삭제</button>
+                            </form>
+                            <button type="button"
+                                    class="btn gray reply-toggle-btn"
+                                    th:attr="data-target=${'reply-form-' + comment.commentId}">답글 달기</button>
+                        </div>
+                    </td>
+                </tr>
+
+                <tr th:id="${'comment-edit-form-' + comment.commentId}" class="comment-edit-row is-hidden">
+                    <td colspan="4">
                         <form method="post"
                               action="/comment/modify"
                               data-comment-action="manage"
@@ -118,63 +157,106 @@
                             <input type="hidden" name="postId" th:value="${board.postId}">
                             <input type="hidden" name="currentMemberId" data-current-member-id-input>
                             <input type="hidden" name="currentRole" data-current-role-input>
-                            <textarea name="content" th:text="${comment.content}" required></textarea>
+
+                            <div class="form-row">
+                                <label th:for="${'commentEdit-' + comment.commentId}">댓글 수정</label>
+                                <textarea th:id="${'commentEdit-' + comment.commentId}"
+                                          name="content"
+                                          th:text="${comment.content}"
+                                          required></textarea>
+                            </div>
+
                             <div class="button-group">
-                                <button type="submit" class="btn">댓글 수정</button>
-                                <button type="submit"
-                                        class="btn red"
-                                        formaction="/comment/delete"
-                                        formmethod="post"
-                                        onclick="return confirm('정말 삭제하시겠습니까?');">댓글 삭제</button>
+                                <button type="submit" class="btn">수정 저장</button>
+                                <button type="button"
+                                        class="btn gray comment-edit-toggle-btn"
+                                        th:attr="data-target=${'comment-edit-form-' + comment.commentId}">닫기</button>
                             </div>
                         </form>
                     </td>
                 </tr>
 
-                <tr th:each="reply : ${commentList}" th:if="${reply.parentCommentId == comment.commentId}">
-                    <td>
-                        <div th:with="writer=${@memberRepository.findById(reply.memberId).orElse(null)}"
-                             style="display: inline-flex; align-items: center; gap: 8px; padding-left: 10px;">
-                            <span style="color: #888; font-weight: bold;">ㄴ</span>
-                            <img th:if="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
-                                 th:src="@{|/uploads/${writer.profile.profileImage}|}"
-                                 onerror="this.src='/img/default-profile.png'"
-                                 alt="프로필"
-                                 style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
-                            <img th:unless="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
-                                 src="/img/default-profile.png"
-                                 alt="기본프로필"
-                                 style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
-                            <span th:text="${reply.memberName != null ? reply.memberName : reply.memberId}">박강사</span>
-                        </div>
-                    </td>
-                    <td th:text="${reply.content}">대댓글 내용</td>
-                    <td th:text="${reply.createdAt}">2026-04-15</td>
-                    <td>
-                        <form method="post"
-                              action="/comment/modify"
-                              data-comment-action="manage"
-                              th:attr="data-post-type=${board.postType},
-                                       data-author-id=${reply.memberId},
-                                       data-course-instructor-id=${board.courseInstructorId}">
-                            <input type="hidden" name="commentId" th:value="${reply.commentId}">
-                            <input type="hidden" name="postId" th:value="${board.postId}">
-                            <input type="hidden" name="currentMemberId" data-current-member-id-input>
-                            <input type="hidden" name="currentRole" data-current-role-input>
-                            <textarea name="content" th:text="${reply.content}" required></textarea>
-                            <div class="button-group">
-                                <button type="submit" class="btn">댓글 수정</button>
-                                <button type="submit"
-                                        class="btn red"
-                                        formaction="/comment/delete"
-                                        formmethod="post"
-                                        onclick="return confirm('정말 삭제하시겠습니까?');">댓글 삭제</button>
+                <th:block th:each="reply : ${commentList}" th:if="${reply.parentCommentId == comment.commentId}">
+                    <tr>
+                        <td>
+                            <div th:with="writer=${@memberRepository.findById(reply.memberId).orElse(null)}"
+                                 style="display: inline-flex; align-items: center; gap: 8px; padding-left: 10px;">
+                                <span style="color: #888; font-weight: bold;">ㄴ</span>
+                                <img th:if="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
+                                     th:src="@{|/uploads/${writer.profile.profileImage}|}"
+                                     onerror="this.src='/img/default-profile.png'"
+                                     alt="profile image"
+                                     style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
+                                <img th:unless="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
+                                     src="/img/default-profile.png"
+                                     alt="default profile image"
+                                     style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
+                                <span th:text="${reply.memberName != null ? reply.memberName : reply.memberId}">박강사</span>
                             </div>
-                        </form>
-                    </td>
-                </tr>
+                        </td>
+                        <td th:text="${reply.content}">대댓글 내용</td>
+                        <td th:text="${#temporals.format(reply.createdAt, 'yyyy년 MM월 dd일 / HH:mm')}">2026년 04월 17일 / 09:43</td>
+                        <td>
+                            <div class="button-group"
+                                 data-comment-action="manage"
+                                 th:attr="data-post-type=${board.postType},
+                                          data-author-id=${reply.memberId},
+                                          data-course-instructor-id=${board.courseInstructorId}">
+                                <button type="button"
+                                        class="btn comment-edit-toggle-btn"
+                                        th:attr="data-target=${'reply-edit-form-' + reply.commentId}">댓글 수정</button>
+                                <form method="post"
+                                      action="/comment/delete"
+                                      style="margin: 0;"
+                                      data-comment-action="manage"
+                                      th:attr="data-post-type=${board.postType},
+                                               data-author-id=${reply.memberId},
+                                               data-course-instructor-id=${board.courseInstructorId}">
+                                    <input type="hidden" name="commentId" th:value="${reply.commentId}">
+                                    <input type="hidden" name="postId" th:value="${board.postId}">
+                                    <input type="hidden" name="currentMemberId" data-current-member-id-input>
+                                    <input type="hidden" name="currentRole" data-current-role-input>
+                                    <button type="submit"
+                                            class="btn red"
+                                            onclick="return confirm('정말 삭제하시겠습니까?');">댓글 삭제</button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
 
-                <tr>
+                    <tr th:id="${'reply-edit-form-' + reply.commentId}" class="comment-edit-row is-hidden">
+                        <td colspan="4">
+                            <form method="post"
+                                  action="/comment/modify"
+                                  data-comment-action="manage"
+                                  th:attr="data-post-type=${board.postType},
+                                           data-author-id=${reply.memberId},
+                                           data-course-instructor-id=${board.courseInstructorId}">
+                                <input type="hidden" name="commentId" th:value="${reply.commentId}">
+                                <input type="hidden" name="postId" th:value="${board.postId}">
+                                <input type="hidden" name="currentMemberId" data-current-member-id-input>
+                                <input type="hidden" name="currentRole" data-current-role-input>
+
+                                <div class="form-row">
+                                    <label th:for="${'replyEdit-' + reply.commentId}">대댓글 수정</label>
+                                    <textarea th:id="${'replyEdit-' + reply.commentId}"
+                                              name="content"
+                                              th:text="${reply.content}"
+                                              required></textarea>
+                                </div>
+
+                                <div class="button-group">
+                                    <button type="submit" class="btn">수정 저장</button>
+                                    <button type="button"
+                                            class="btn gray comment-edit-toggle-btn"
+                                            th:attr="data-target=${'reply-edit-form-' + reply.commentId}">닫기</button>
+                                </div>
+                            </form>
+                        </td>
+                    </tr>
+                </th:block>
+
+                <tr th:id="${'reply-form-' + comment.commentId}" class="reply-form-row is-hidden">
                     <td colspan="4">
                         <form method="post" action="/comment/regist">
                             <input type="hidden" name="postId" th:value="${board.postId}">
@@ -190,6 +272,9 @@
 
                             <div class="button-group">
                                 <button type="submit" class="btn gray">답글 등록</button>
+                                <button type="button"
+                                        class="btn reply-toggle-btn"
+                                        th:attr="data-target=${'reply-form-' + comment.commentId}">닫기</button>
                             </div>
                         </form>
                     </td>
@@ -223,6 +308,58 @@
         </form>
     </div>
 </div>
+
+<script th:inline="javascript">
+    document.addEventListener("DOMContentLoaded", function () {
+        const postId = document.body.dataset.postId;
+        const navigationEntry = performance.getEntriesByType("navigation")[0];
+        const navigationType = navigationEntry ? navigationEntry.type : null;
+
+        if (postId && navigationType !== "reload") {
+            fetch("/board/view-count", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded"
+                },
+                body: new URLSearchParams({
+                    postId: postId
+                })
+            }).catch(() => {
+                console.warn("조회수 증가 요청에 실패했습니다.");
+            });
+        }
+
+        function toggleSingleTarget(buttonSelector, rowSelector) {
+            document.querySelectorAll(buttonSelector).forEach(function (button) {
+                button.addEventListener("click", function () {
+                    const targetId = button.dataset.target;
+                    const target = document.getElementById(targetId);
+
+                    if (!target) {
+                        return;
+                    }
+
+                    const isOpen = !target.classList.contains("is-hidden");
+
+                    document.querySelectorAll(rowSelector).forEach(function (row) {
+                        row.classList.add("is-hidden");
+                    });
+
+                    if (!isOpen) {
+                        target.classList.remove("is-hidden");
+                        const textarea = target.querySelector("textarea");
+                        if (textarea) {
+                            textarea.focus();
+                        }
+                    }
+                });
+            });
+        }
+
+        toggleSingleTarget(".reply-toggle-btn", ".reply-form-row");
+        toggleSingleTarget(".comment-edit-toggle-btn", ".comment-edit-row");
+    });
+</script>
 <script src="/js/board/role-switcher.js"></script>
 <script th:if="${errorMessage != null}" th:inline="javascript">
     alert([[${errorMessage}]]);

--- a/src/main/resources/templates/board/free-list.html
+++ b/src/main/resources/templates/board/free-list.html
@@ -9,35 +9,45 @@
 <div class="page-wrapper">
     <div class="top-utility">
         <div class="role-panel">
-            <p class="role-label">현재 역할 전환</p>
+            <p class="role-label">현재 로그인 정보</p>
             <div class="role-buttons">
                 <button class="role-btn" data-role="ADMIN" type="button">관리자</button>
                 <button class="role-btn" data-role="INSTRUCTOR" type="button">강사</button>
                 <button class="role-btn" data-role="STUDENT" type="button">학생</button>
             </div>
-            <div class="role-current">현재 로그인: <span class="role-badge" data-current-role th:text="${currentRole}">STUDENT</span> / 사용자 ID: <span class="role-badge" data-current-member-id th:text="${currentMemberId}">1</span></div>
-            <p class="permission-note">자유게시판은 등록은 열려 있지만 수정, 삭제는 본인 글만 가능합니다.</p>
+            <div class="role-current">
+                현재 역할:
+                <span class="role-badge" data-current-role th:text="${currentRole}">STUDENT</span>
+                / 회원 ID:
+                <span class="role-badge" data-current-member-id th:text="${currentMemberId}">1</span>
+            </div>
+            <p class="permission-note">자유게시판은 관리자, 강사, 학생이 자유롭게 소통할 수 있는 공간입니다.</p>
         </div>
         <div class="page-main">
-            <h1 class="page-title">자유게시판 목록</h1>
-            <p class="page-desc">학생과 강사가 자유롭게 소통하는 게시판입니다.</p>
+            <div class="page-eyebrow">Free Board</div>
+            <h1 class="page-title">자유게시판</h1>
+            <p class="page-desc">질문, 후기, 잡담 등 다양한 이야기를 편하게 나눌 수 있는 게시판입니다.</p>
         </div>
     </div>
 
     <div class="box">
         <div class="button-group">
             <a class="btn" href="/board/regist?type=FREE" data-role-only="ADMIN,INSTRUCTOR,STUDENT">글쓰기</a>
-            <a class="btn gray" href="/board/list">게시판 메인</a>
+            <a class="btn gray" href="/board/list">게시판 홈</a>
         </div>
     </div>
 
     <div class="box">
         <form class="search-bar" method="get" action="/board/free">
-            <input type="text" name="keyword" placeholder="자유게시판 제목 검색" th:value="${keyword}">
+            <input type="text" name="keyword" placeholder="검색어를 입력하세요" th:value="${keyword}">
             <button type="submit" class="btn">검색</button>
             <a class="btn gray" href="/board/free">초기화</a>
         </form>
-        <p class="meta">검색어: <span th:text="${keyword != null and !keyword.isBlank() ? keyword : '전체'}">전체</span></p>
+        <p class="meta">
+            검색 기준:
+            <span th:if="${keyword != null and !keyword.isBlank()}" th:text="${keyword}">keyword</span>
+            <span th:unless="${keyword != null and !keyword.isBlank()}">전체</span>
+        </p>
 
         <table class="table">
             <thead>
@@ -49,37 +59,38 @@
             </tr>
             </thead>
             <tbody>
-            <tr th:each="board, stat : ${boardList}">
+            <tr th:each="board, stat : ${boardList}"
+                class="post-row"
+                th:attr="data-href=@{/board/detail(postId=${board.postId})}">
                 <td th:text="${stat.count}">1</td>
-                <td><a th:href="@{/board/detail(postId=${board.postId})}" th:text="${board.title}">자유글 제목</a></td>
-
+                <td>
+                    <a th:href="@{/board/detail(postId=${board.postId})}" th:text="${board.title}">자유게시판 제목</a>
+                </td>
                 <td>
                     <div th:with="writer=${@memberRepository.findById(board.memberId).orElse(null)}"
                          style="display: inline-flex; align-items: center; gap: 8px;">
-
                         <img th:if="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
                              th:src="@{|/uploads/${writer.profile.profileImage}|}"
                              onerror="this.src='/img/default-profile.png'"
-                             alt="프로필"
+                             alt="profile image"
                              style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
-
                         <img th:unless="${writer?.profile?.profileImage != null and writer.profile.profileImage != 'default-profile.png'}"
                              src="/img/default-profile.png"
-                             alt="기본프로필"
+                             alt="default profile image"
                              style="width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid #dbe3f1;">
-
-                        <span th:text="${board.memberName != null ? board.memberName : board.memberId}">이학생</span>
+                        <span th:text="${board.memberName != null ? board.memberName : board.memberId}">홍길동</span>
                     </div>
                 </td>
                 <td th:text="${board.viewCount}">12</td>
             </tr>
             <tr th:if="${boardList == null or #lists.isEmpty(boardList)}">
-                <td colspan="4">조회된 자유게시판 글이 없습니다.</td>
+                <td colspan="4">등록된 자유게시판 글이 없습니다.</td>
             </tr>
             </tbody>
         </table>
     </div>
 </div>
 <script src="/js/board/role-switcher.js"></script>
+<script src="/js/board/post-row.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/board/list.html
+++ b/src/main/resources/templates/board/list.html
@@ -2,15 +2,19 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>게시판 메인</title>
     <link rel="stylesheet" href="/css/board/crud.css">
 </head>
 <body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId}">
 <div class="page-wrapper">
     <div class="top-utility">
-        <div class="page-main">
+        <div class="page-main box" style="margin-bottom: 0;">
+            <span class="page-eyebrow">Board Hub</span>
             <h1 class="page-title">게시판 메인</h1>
-            <p class="page-desc">게시판 종류를 선택해서 원하는 목록으로 이동하면 된다.</p>
+            <p class="page-desc">
+                원하는 게시판 종류를 선택해서 공지와 커뮤니티, 질의응답 화면으로 빠르게 이동할 수 있습니다.
+            </p>
         </div>
     </div>
 
@@ -18,25 +22,20 @@
         <h2 class="section-title">게시판 종류</h2>
         <div class="card-grid">
             <a class="feature-card" href="/board/admin-notices">
+                <span class="card-tag">Admin Notice</span>
                 <h3>관리자 공지</h3>
-                <p>관리자가 작성하는 전체 공지 게시판이다.</p>
+                <p>관리자가 작성하는 전체 공지 게시판입니다. 시스템 안내와 공통 공지사항을 확인할 수 있습니다.</p>
             </a>
             <a class="feature-card" href="/board/course-notices">
+                <span class="card-tag">Course Notice</span>
                 <h3>코스 공지</h3>
-                <p>강사가 코스 단위로 작성하는 공지 게시판이다.</p>
+                <p>강사가 코스 단위로 작성하는 공지 게시판입니다. 강의별 중요한 전달사항을 확인할 수 있습니다.</p>
             </a>
             <a class="feature-card" href="/board/free">
+                <span class="card-tag">Community</span>
                 <h3>자유게시판</h3>
-                <p>학생과 강사가 자유롭게 소통하는 게시판이다.</p>
+                <p>학생과 강사가 자유롭게 소통하는 공간입니다. 학습 관련 이야기와 일상 대화를 나눌 수 있습니다.</p>
             </a>
-        </div>
-    </div>
-
-    <div class="box">
-        <h2 class="section-title">바로가기</h2>
-        <div class="button-group">
-            <a class="btn" href="/board/regist?type=FREE" data-role-only="ADMIN,INSTRUCTOR,STUDENT">게시글 등록</a>
-            <a class="btn gray" href="/main">메인으로</a>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/board/section-qna-list.html
+++ b/src/main/resources/templates/board/section-qna-list.html
@@ -2,46 +2,53 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>섹션 Q&amp;A 목록</title>
+    <title>섹션 Q&A 목록</title>
     <link rel="stylesheet" href="/css/board/crud.css">
 </head>
 <body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId}">
 <div class="page-wrapper">
     <div class="top-utility">
         <div class="role-panel">
-            <p class="role-label">현재 역할 전환</p>
+            <p class="role-label">현재 로그인 정보</p>
             <div class="role-buttons">
                 <button class="role-btn" data-role="ADMIN" type="button">관리자</button>
                 <button class="role-btn" data-role="INSTRUCTOR" type="button">강사</button>
                 <button class="role-btn" data-role="STUDENT" type="button">학생</button>
             </div>
-            <div class="role-current">현재 로그인: <span class="role-badge" data-current-role th:text="${currentRole}">STUDENT</span> / 사용자 ID: <span class="role-badge" data-current-member-id th:text="${currentMemberId}">1</span></div>
-            <p class="permission-note">비밀 질문은 강사, 관리자, 작성자 학생만 내용을 확인할 수 있습니다.</p>
+            <div class="role-current">
+                현재 역할:
+                <span class="role-badge" data-current-role th:text="${currentRole}">STUDENT</span>
+                / 회원 ID:
+                <span class="role-badge" data-current-member-id th:text="${currentMemberId}">1</span>
+            </div>
+            <p class="permission-note">섹션 Q&A는 학생 질문과 강사 답변을 위한 게시판입니다.</p>
         </div>
         <div class="page-main">
-            <h1 class="page-title">섹션 Q&amp;A 목록</h1>
-            <p class="page-desc">학생 질문과 답변 상태를 확인하는 게시판입니다.</p>
+            <div class="page-eyebrow">Section Q&A</div>
+            <h1 class="page-title">섹션 Q&A</h1>
+            <p class="page-desc">강의 중 궁금한 내용을 질문하고 답변 상태를 함께 확인할 수 있습니다.</p>
         </div>
     </div>
 
     <div class="box">
         <div class="button-group">
-            <a class="btn"
-               th:href="@{/board/regist(type='SECTION_QNA', courseId=${courseId})}"
-               data-role-only="STUDENT">질문 등록</a>
-            <a class="btn gray" href="/board/list">게시판 메인</a>
+            <a class="btn" th:href="@{/board/regist(type='SECTION_QNA', courseId=${courseId})}" data-role-only="STUDENT">질문 등록</a>
+            <a class="btn gray" href="/board/list">게시판 홈</a>
         </div>
     </div>
 
     <div class="box">
         <form class="search-bar" method="get" action="/board/section-qna">
             <input type="hidden" name="courseId" th:value="${courseId}">
-            <input type="text" name="keyword" placeholder="섹션 Q&amp;A 제목 검색" th:value="${keyword}">
+            <input type="text" name="keyword" placeholder="검색어를 입력하세요" th:value="${keyword}">
             <button type="submit" class="btn">검색</button>
-            <a class="btn gray"
-               th:href="@{/board/section-qna(courseId=${courseId})}">초기화</a>
+            <a class="btn gray" th:href="@{/board/section-qna(courseId=${courseId})}">초기화</a>
         </form>
-        <p class="meta">검색어: <span th:text="${keyword != null and !keyword.isBlank() ? keyword : '전체'}">전체</span></p>
+        <p class="meta">
+            검색 기준:
+            <span th:if="${keyword != null and !keyword.isBlank()}" th:text="${keyword}">keyword</span>
+            <span th:unless="${keyword != null and !keyword.isBlank()}">전체</span>
+        </p>
 
         <table class="table">
             <thead>
@@ -54,7 +61,9 @@
             </tr>
             </thead>
             <tbody>
-            <tr th:each="board, stat : ${boardList}">
+            <tr th:each="board, stat : ${boardList}"
+                class="post-row"
+                th:attr="data-href=@{/board/detail(postId=${board.postId})}">
                 <td th:text="${stat.count}">1</td>
                 <td>
                     <a th:href="@{/board/detail(postId=${board.postId})}"
@@ -64,15 +73,16 @@
                 </td>
                 <td th:text="${board.isSecret} ? 'Y' : 'N'">Y</td>
                 <td th:text="${board.answerStatus != null ? board.answerStatus : '-'}">PENDING</td>
-                <td th:text="${board.memberName != null ? board.memberName : board.memberId}">김학생</td>
+                <td th:text="${board.memberName != null ? board.memberName : board.memberId}">학생1</td>
             </tr>
             <tr th:if="${boardList == null or #lists.isEmpty(boardList)}">
-                <td colspan="5">조회된 섹션 Q&amp;A가 없습니다.</td>
+                <td colspan="5">등록된 섹션 Q&A 글이 없습니다.</td>
             </tr>
             </tbody>
         </table>
     </div>
 </div>
 <script src="/js/board/role-switcher.js"></script>
+<script src="/js/board/post-row.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/student/attendance/attendancepage.html
+++ b/src/main/resources/templates/student/attendance/attendancepage.html
@@ -224,13 +224,15 @@
                         <span th:text="|${attendancePage.totalScore}점 / 100점|">80점 / 100점</span>
                     </div>
 
-                    <div th:if="${attendancePage.totalScore >= 80 and attendancePage.certificateStatus == 'NONE'}">
-                        <a class="inline-flex items-center rounded-xl bg-primary px-5 py-3 text-sm font-bold text-on-primary shadow-sm transition-all hover:brightness-105"
-                           th:href="@{/student/certificate/request(courseId=${attendancePage.courseId})}">
-                            <span class="material-symbols-outlined mr-2 text-base">workspace_premium</span>
+                    <form th:if="${attendancePage.totalScore >= 80 and attendancePage.certificateStatus == 'NONE'}"
+                          th:action="@{/student/certificate/request}"
+                          method="post">
+                        <input type="hidden" name="courseId" th:value="${attendancePage.courseId}">
+                        <button type="submit"
+                                class="inline-flex items-center rounded-xl bg-primary px-5 py-3 text-sm font-bold text-white">
                             수료증 발급 신청
-                        </a>
-                    </div>
+                        </button>
+                    </form>
 
                     <button th:if="${attendancePage.certificateStatus == 'REQUESTED'}"
                             class="inline-flex items-center rounded-xl bg-surface-container-high px-5 py-3 text-sm font-bold text-on-surface-variant"
@@ -240,7 +242,8 @@
                         승인 대기
                     </button>
 
-                    <a th:if="${attendancePage.certificateStatus == 'APPROVED'}"
+                    <a th:if="${attendancePage.certificateStatus == 'APPROVED' or attendancePage.certificateStatus == 'ISSUED'}"
+
                        class="inline-flex items-center rounded-xl bg-primary px-5 py-3 text-sm font-bold text-on-primary shadow-sm transition-all hover:brightness-105"
                        th:href="@{/student/certificate(courseId=${attendancePage.courseId})}">
                         <span class="material-symbols-outlined mr-2 text-base">workspace_premium</span>


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당하는 항목에 체크하세요 -->
- [ ] ✨ FEATURE
- [x] 🔧 UPDATE
- [x] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 🔗 관련 이슈
Closes #124 

---

## 🛠️ 작업 내용
- 게시판 목록에서 제목뿐 아니라 게시글 행 전체를 클릭해 상세 페이지로 이동할 수 있도록 수정했다.
- 게시글 상세 페이지에서 답글 작성 폼을 토글 방식으로 변경해 선택한 댓글에서만 열리도록 수정했습다.
- 댓글/대댓글 수정 폼을 토글 방식으로 변경하고 작성일 표시 형식을 사용자 친화적으로 정리했다.

---


---

## 🔄 변경 사항
- `admin-notice-list.html`, `course-notice-list.html`, `free-list.html`, `section-qna-list.html`에 행 클릭 이동 처리를 추가하고 공통 스크립트와 스타일을 적용했다.
- `detail.html`의 댓글/대댓글 영역을 재구성해 답글 및 수정 입력폼이 기본 숨김 상태에서 버튼 클릭 시 열리도록 변경했다.
- 댓글 작성일을 `yyyy년 MM월 dd일 / HH:mm` 형식으로 출력하도록 수정하고, 버튼 배치 및 댓글 액션 UI를 정리했다.

---


---

## ✅ 체크리스트
- [x] 팀 코딩 컨벤션을 준수했습니다.
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 불필요한 코드는 제거했습니다.
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우).