### PR TITLE
[UPDATE] 섹션 Q&A 답변 상태 및 강사 화면 연동 개선

### DIFF
--- a/src/main/java/com/wanted/projectmodule2lms/domain/board/model/dao/BoardRepository.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/board/model/dao/BoardRepository.java
@@ -1,4 +1,5 @@
 package com.wanted.projectmodule2lms.domain.board.model.dao;
+import com.wanted.projectmodule2lms.domain.board.model.entity.AnswerStatus;
 import com.wanted.projectmodule2lms.domain.board.model.entity.Board;
 import com.wanted.projectmodule2lms.domain.board.model.entity.BoardType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,11 @@ public interface BoardRepository extends JpaRepository<Board, Integer> {
     List<Board> findByTitleContainingAndIsDeletedFalse(String title);
 
     List<Board> findByPostTypeAndTitleContainingAndIsDeletedFalse(BoardType postType, String title);
+
+    long countByCourseIdAndPostTypeAndAnswerStatusAndIsDeletedFalse(
+            Integer courseId,
+            BoardType postType,
+            AnswerStatus answerStatus
+    );
+
 }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/board/model/entity/Board.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/board/model/entity/Board.java
@@ -91,6 +91,10 @@ public class Board {
         this.answerStatus = answerStatus;
     }
 
+    public void changeAnswerStatus(AnswerStatus answerStatus) {
+        this.answerStatus = answerStatus;
+    }
+
     public static class Builder {
         private Integer memberId;
         private Integer courseId;
@@ -107,6 +111,8 @@ public class Board {
             this.memberId = memberId;
             return this;
         }
+
+
 
         public Builder courseId(Integer courseId) {
             this.courseId = courseId;
@@ -166,4 +172,6 @@ public class Board {
     public void increasedViewCount() {
         this.viewCount++;
     }
+
+
 }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/board/model/service/BoardService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/board/model/service/BoardService.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class BoardService {
+public class    BoardService {
 
     private final BoardRepository boardRepository;
     private final CourseRepository courseRepository;
@@ -519,5 +519,15 @@ public class BoardService {
     public void increaseViewCount(Integer postId) {
         Board board = findActiveBoard(postId);
         board.increasedViewCount();
+    }
+
+    @Transactional
+    public void changeAnswerStatusToAnswered(Integer postId) {
+        Board board = findActiveBoard(postId);
+
+        if (board.getPostType() != BoardType.SECTION_QNA) {
+            return;
+        }
+        board.changeAnswerStatus(AnswerStatus.ANSWERED);
     }
 }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/service/CommentService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/service/CommentService.java
@@ -70,6 +70,9 @@ public class CommentService {
                 commentDTO.getContent()
         );
         commentRepository.save(comment);
+        if(board.getPostType() == BoardType.SECTION_QNA && currentRole == MemberRole.INSTRUCTOR) {
+            boardService.changeAnswerStatusToAnswered(commentDTO.getPostId());
+        }
     }
 
     @Transactional

--- a/src/main/java/com/wanted/projectmodule2lms/domain/grade/model/dto/InstructorGradeDashboardDTO.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/grade/model/dto/InstructorGradeDashboardDTO.java
@@ -15,4 +15,5 @@ public class InstructorGradeDashboardDTO {
     private Integer lateCount;
     private Integer absentCount;
     private Integer missingAssignmentStudentCount;
+    private Integer pendingQuestionCount;
 }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/grade/model/service/GradeService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/grade/model/service/GradeService.java
@@ -5,6 +5,9 @@ import com.wanted.projectmodule2lms.domain.assignment.model.entity.Assignment;
 import com.wanted.projectmodule2lms.domain.attendance.model.dao.AttendanceRepository;
 import com.wanted.projectmodule2lms.domain.attendance.model.entity.Attendance;
 import com.wanted.projectmodule2lms.domain.attendance.model.entity.AttendanceStatus;
+import com.wanted.projectmodule2lms.domain.board.model.dao.BoardRepository;
+import com.wanted.projectmodule2lms.domain.board.model.entity.AnswerStatus;
+import com.wanted.projectmodule2lms.domain.board.model.entity.BoardType;
 import com.wanted.projectmodule2lms.domain.course.model.dao.CourseRepository;
 import com.wanted.projectmodule2lms.domain.course.model.entity.Course;
 import com.wanted.projectmodule2lms.domain.enrollment.model.dao.EnrollmentRepository;
@@ -49,6 +52,7 @@ public class GradeService {
     private final SectionRepository sectionRepository;
     private final AssignmentRepository assignmentRepository;
     private final SubmissionRepository submissionRepository;
+    private final BoardRepository boardRepository;
 
     public List<GradeDTO> findGradesByMemberId(Integer memberId) {
         List<Enrollment> enrollments = enrollmentRepository.findByMemberId(memberId);
@@ -332,7 +336,11 @@ public class GradeService {
         if (!course.getInstructorId().equals(instructorId)) {
             throw new IllegalArgumentException("해당 강의만 조회할 수 있습니다.");
         }
-
+        int pendingQuestionCount= (int) boardRepository.countByCourseIdAndPostTypeAndAnswerStatusAndIsDeletedFalse(
+                courseId,
+                BoardType.SECTION_QNA,
+                AnswerStatus.PENDING
+        );
         List<Enrollment> enrollments = enrollmentRepository.findByCourseId(courseId);
         int totalStudentCount = enrollments.size();
         long totalSectionCount = sectionRepository.countByCourseId(courseId);
@@ -340,6 +348,7 @@ public class GradeService {
         if (totalSectionCount == 0) {
             return new InstructorGradeDashboardDTO(
                     totalStudentCount,
+                    0,
                     0,
                     0,
                     0,
@@ -394,7 +403,8 @@ public class GradeService {
                 averageProgressRate,
                 lateCount,
                 absentCount,
-                missingAssignmentStudentCount
+                missingAssignmentStudentCount,
+                pendingQuestionCount
         );
     }
 

--- a/src/main/resources/templates/board/detail.html
+++ b/src/main/resources/templates/board/detail.html
@@ -50,7 +50,7 @@
             코스: <span th:text="${board.courseTitle != null ? board.courseTitle : '-'}">Spring Boot 입문</span><br>
             섹션 ID: <span th:text="${board.sectionId != null ? board.sectionId : '-'}">2</span><br>
             비밀글 여부: <span th:text="${board.isSecret} ? 'Y' : 'N'">N</span><br>
-            답변 상태: <span th:text="${board.answerStatus != null ? board.answerStatus : '-'}">PENDING</span><br>
+            답변 상태: <span th:text="${board.answerStatus == T(com.wanted.projectmodule2lms.domain.board.model.entity.AnswerStatus).PENDING ? '답변대기' : (board.answerStatus == T(com.wanted.projectmodule2lms.domain.board.model.entity.AnswerStatus).ANSWERED ? '답변완료' : '-')}">답변대기</span><br>
             조회수: <span th:text="${board.viewCount}">120</span>
         </div>
 

--- a/src/main/resources/templates/board/section-qna-list.html
+++ b/src/main/resources/templates/board/section-qna-list.html
@@ -72,7 +72,7 @@
                     </a>
                 </td>
                 <td th:text="${board.isSecret} ? 'Y' : 'N'">Y</td>
-                <td th:text="${board.answerStatus != null ? board.answerStatus : '-'}">PENDING</td>
+                <td th:text="${board.answerStatus == T(com.wanted.projectmodule2lms.domain.board.model.entity.AnswerStatus).PENDING ? '답변대기' : (board.answerStatus == T(com.wanted.projectmodule2lms.domain.board.model.entity.AnswerStatus).ANSWERED ? '답변완료' : '-')}">답변대기</td>
                 <td th:text="${board.memberName != null ? board.memberName : board.memberId}">학생1</td>
             </tr>
             <tr th:if="${boardList == null or #lists.isEmpty(boardList)}">

--- a/src/main/resources/templates/instructor/grade/list-view.html
+++ b/src/main/resources/templates/instructor/grade/list-view.html
@@ -68,7 +68,7 @@
 
         .stats-grid {
             display: grid;
-            grid-template-columns: repeat(4, minmax(0, 1fr));
+            grid-template-columns: repeat(5, minmax(0, 1fr));
             gap: 18px;
             margin: 28px 0 32px;
         }
@@ -85,10 +85,13 @@
             border-left: 6px solid #2052c9;
         }
 
+
         .stat-card.orange {
             border-left: 6px solid #bb4d00;
         }
-
+        .stat-card.yellow {
+            border-left: 6px solid #ffc107;
+        }
         .stat-card.red {
             border-left: 6px solid #d62939;
         }
@@ -192,7 +195,11 @@
             white-space: nowrap;
             font-size: 0.95rem;
         }
-
+        .top-link-group {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+        }
         tbody tr:hover {
             background: #fafcff;
         }
@@ -271,13 +278,17 @@
     <a class="brand-link" th:href="@{/main}">64Lab</a>
 
     <section class="hero">
-        <div class="hero-top">
-            <div>
-                <h2>강사 성적 관리</h2>
-                <p th:if="${selectedCourseId != null}">선택한 코스의 학생 현황과 성적 정보를 한 화면에서 확인합니다.</p>
-                <p th:unless="${selectedCourseId != null}">코스를 선택하면 학생 목록과 요약 통계를 함께 볼 수 있습니다.</p>
-            </div>
-            <a class="top-link" th:href="@{/instructor/grades/courses}">강의 목록으로</a>
+        <div class="top-link-group">
+            <a class="top-link"
+               th:if="${selectedCourseId != null}"
+               th:href="@{/board/section-qna(courseId=${selectedCourseId})}">
+                섹션 Q&A
+            </a>
+
+            <a class="top-link"
+               th:href="@{/instructor/grades/courses}">
+                강의 목록으로
+            </a>
         </div>
     </section>
 
@@ -315,6 +326,12 @@
             <p class="stat-label">미제출 과제</p>
             <p class="stat-value" th:text="${dashboard.missingAssignmentStudentCount}">0</p>
             <p class="stat-sub">과제를 제출하지 않은 학생 수입니다.</p>
+        </article>
+
+        <article class="stat-card yellow">
+            <p class="stat-label">답변 대기 질문</p>
+            <p class="stat-value" th:text="${dashboard.pendingQuestionCount}">0</p>
+            <p class="stat-sub">아직 답변되지 않은 섹션 Q&A 질문 수입니다.</p>
         </article>
     </section>
 


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당하는 항목에 체크하세요 -->
- [ ] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 🔗 관련 이슈
Closes #129 

---

## 🛠️ 작업 내용
- 섹션 Q&A 답변 상태가 영어 enum 값으로 노출되던 부분을 한글 상태값으로 표시되도록 수정했습니다.
- 강사 답변 등록 시 섹션 Q&A 게시글의 답변 상태가 자동으로 변경될 수 있도록 로직을 정리했습니다.
- 강사 성적 관리 화면에서 해당 코스의 섹션 Q&A 이동 및 답변 대기 질문 수 확인 기능을 추가할 수 있도록 구조를 정리했습니다.

---

## 🔄 변경 사항
- 기존에는 섹션 Q&A 화면에서 `PENDING`, `ANSWERED` 값이 그대로 보여 사용자가 상태를 직관적으로 이해하기 어려웠습니다.
- 강사가 질문글에 답변해도 게시글 상태와 실제 답변 여부가 바로 연결되지 않아 상태 반영 기준을 개선할 필요가 있었습니다.
- 강사 성적 화면에서 해당 코스의 Q&A 게시판으로 바로 이동하거나 답변 대기 질문 수를 확인할 수 있도록 화면 연동 방향을 정리했습니다.

---

## ✅ 체크리스트
- [x] 팀 코딩 컨벤션을 준수했습니다.
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 불필요한 코드는 제거했습니다.
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우).