### PR TITLE
[UPDATE] 1.수강 신청 화면 버튼 숨기고 상세 안에서 수강 신청 누르기 2.캘린더 페이지 Ui 수정 5.today 기능, 선택 된것 색깔 다르게, 3. month 빼기 

### DIFF
--- a/src/main/resources/templates/main/main.html
+++ b/src/main/resources/templates/main/main.html
@@ -168,6 +168,22 @@
                 transition: none;
             }
         }
+
+        #dashboardCalendar .fc-daygrid-day.fc-day-selected {
+            background: rgba(67, 87, 181, 0.14) !important;
+        }
+
+        #dashboardCalendar .fc-daygrid-day.fc-day-selected .fc-daygrid-day-frame {
+            background: rgba(67, 87, 181, 0.14) !important;
+            box-shadow: inset 0 0 0 2px #4357b5;
+            border-radius: 14px;
+        }
+
+        #dashboardCalendar .fc-daygrid-day.fc-day-selected .fc-daygrid-day-number {
+            color: #233876 !important;
+            font-weight: 800;
+        }
+
     </style>
 </head>
 <body class="text-ink">
@@ -902,6 +918,38 @@
         }).join('');
     }
 
+    function applySelectedDateHighlight() {
+        if (!calendarInstance) return;
+
+        const cells = document.querySelectorAll('#dashboardCalendar .fc-daygrid-day');
+        cells.forEach(cell => {
+            cell.classList.remove('fc-day-selected');
+        });
+
+        if (!selectedDate) return;
+
+        const selectedCell = document.querySelector(
+            `#dashboardCalendar .fc-daygrid-day[data-date="${selectedDate}"]`
+        );
+
+        if (selectedCell) {
+            selectedCell.classList.add('fc-day-selected');
+        }
+    }
+
+    function setSelectedDate(dateStr, moveCalendar = false) {
+        selectedDate = dateStr;
+
+        if (moveCalendar && calendarInstance) {
+            calendarInstance.gotoDate(dateStr);
+        }
+
+        renderSelectedEvents(allEvents, selectedDate);
+        loadMemos(selectedDate);
+        applySelectedDateHighlight();
+    }
+
+
     function renderDdayList(events) {
         const ddayList = document.getElementById('ddayList');
         if (!ddayList) return;
@@ -1198,20 +1246,35 @@
                     locale: 'ko',
                     height: 'auto',
                     headerToolbar: {
-                        left: 'prev,next today',
+                        left: 'prev,next customToday',
                         center: 'title',
-                        right: 'dayGridMonth'
+                        right: ''
+                    },
+                    customButtons: {
+                        customToday: {
+                            text: 'today',
+                            click: function() {
+                                const todayStr = getTodayString();
+                                setSelectedDate(todayStr, true);
+                            }
+                        }
                     },
                     events: allEvents,
                     dateClick: function(info) {
-                        selectedDate = info.dateStr;
-                        renderSelectedEvents(allEvents, selectedDate);
-                        loadMemos(selectedDate);
+                        setSelectedDate(info.dateStr);
+                    },
+                    datesSet: function() {
+                        applySelectedDateHighlight();
                     }
                 });
 
                 calendarInstance.render();
+
+                const todayStr = getTodayString();
+                setSelectedDate(todayStr);
+
                 renderDdayList(allEvents);
+
             })
             .catch(() => {
                 const selectedScheduleList = document.getElementById('selectedScheduleList');

--- a/src/main/resources/templates/student/enrollment/list.html
+++ b/src/main/resources/templates/student/enrollment/list.html
@@ -91,7 +91,9 @@
     </div>
 
     <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
-        <div th:each="course : ${courseList}" class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <a th:each="course : ${courseList}"
+           th:href="@{/student/enrollments/courses/{courseId}(courseId=${course.courseId})}"
+           class="block rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-md">
             <div class="mb-4 flex items-start justify-between">
                 <span class="text-sm text-slate-500" th:text="${course.category}">카테고리</span>
                 <span class="rounded-full bg-blue-100 px-3 py-1 text-xs text-blue-700">OPEN</span>
@@ -105,28 +107,16 @@
                 <p th:text="|기간: ${course.startDate} ~ ${course.endDate}|"></p>
             </div>
 
-            <div class="mt-6 flex flex-wrap items-center gap-2">
-                <a th:href="@{/student/enrollments/courses/{courseId}(courseId=${course.courseId})}"
-                   class="rounded-lg bg-slate-900 px-4 py-2 text-sm text-white hover:bg-slate-700">
-                    강의 상세
-                </a>
+            <div class="mt-6 flex items-center justify-between">
+                <span class="text-sm font-semibold text-slate-500">클릭해서 상세 보기</span>
 
                 <th:block th:if="${enrolledCourseIds.contains(course.courseId)}">
                     <span class="rounded-lg bg-slate-200 px-4 py-2 text-sm text-slate-600">수강중</span>
                 </th:block>
-
-                <th:block th:unless="${enrolledCourseIds.contains(course.courseId)}">
-                    <form th:action="@{/student/enrollments}" method="post" class="enroll-form">
-                        <input type="hidden" name="courseId" th:value="${course.courseId}">
-                        <button type="button"
-                                class="open-enroll-modal rounded-lg bg-blue-700 px-4 py-2 text-sm text-white hover:bg-blue-800">
-                            수강신청
-                        </button>
-                    </form>
-                </th:block>
             </div>
-        </div>
+        </a>
     </div>
+
 
     <div th:if="${#lists.isEmpty(courseList)}"
          class="mt-8 rounded-xl border border-slate-200 bg-white p-8 text-center text-slate-500">


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당하는 항목에 체크하세요 -->
- [ ] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 🔗 관련 이슈
Closes #138 

---

## 🛠️ 작업 내용
-  1.수강 신청 화면 버튼 숨기고 상세 안에서 수강 신청 누르기 2.캘린더 페이지 Ui 수정 3.today 기능, 선택 된것 색깔 다르게,month 빼기
- 
- 

---

## 🔄 변경 사항
- student/enrollment/list.html에서는 카드 안의 강의 상세, 수강신청 버튼을 없애고 카드 자체를 상세 페이지 링크로 바꾸는 쪽으로 정리했고, 실제 신청은 student/enrollment/detail.html에서만 하도록 잡았습니다. 상세 페이지의 신청 버튼에는 확인 문구와 예 / 아니오가 있는 확인 모달을 붙이는 방향으로 봤습니다.

강사 성적 관리 화면에서는 버튼 문구만 바꾸는 위치를 찾았습니다.
grade/list-view.html에서 관리 화면 텍스트를 출석 관리로 바꾸면 되고, 필요하면 같은 파일의 안내 문구에 들어간 관리 화면 표현도 같이 맞추면 됩니다.

메인 캘린더는 today 버튼 동작을 확장하는 방향으로 정리했습니다.
main.html에서 today 클릭 시 단순히 오늘 달로만 이동하는 게 아니라, 오른쪽 패널의 선택 날짜도 오늘로 바꾸고, 캘린더 안에서도 오늘 날짜 칸이 선택 상태로 강조되게 만들도록 봤습니다. 이를 위해 selectedDate를 한 군데서 처리하는 공통 함수와 선택 날짜 하이라이트 클래스를 추가하는 구조로 정리했고, 오른쪽의 month 버튼은 같은 파일의 headerToolbar.right에서 dayGridMonth를 제거하면 사라지도록 확인했습니다. initialView: 'dayGridMonth'는 버튼이 아니라 월간 보기 기본 설정이라 그대로 두는 게 맞다고 정리했습니다.
- 
- 

---

## ✅ 체크리스트
- [x] 팀 코딩 컨벤션을 준수했습니다.
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 불필요한 코드는 제거했습니다.
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우).