### PR TITLE
[UPDATE] 댓글/출석 조회 성능 최적화 및 반복 DB 접근 개선

### DIFF
--- a/src/main/java/com/wanted/projectmodule2lms/domain/attendance/model/dao/AttendanceRepository.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/attendance/model/dao/AttendanceRepository.java
@@ -16,4 +16,7 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Integer>
     List<Attendance> findByEnrollmentId(Integer enrollmentId);
 
     List<Attendance> findByEnrollmentIdOrderBySectionIdAsc(Integer enrollmentId);
+
+    List<Attendance> findByEnrollmentIdInOrderByEnrollmentIdAscSectionIdAsc(List<Integer> enrollmentIds);
+
 }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/attendance/model/service/AttendanceService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/attendance/model/service/AttendanceService.java
@@ -135,7 +135,8 @@ public class AttendanceService {
         int weightedAssignmentScore = calculateWeightedScore(assignmentScore, ASSIGNMENT_MAX_SCORE);
         int weightedExamScore = calculateWeightedScore(examScore, EXAM_MAX_SCORE);
         int weightedAttitudeScore = calculateWeightedScore(attitudeScore, ATTITUDE_MAX_SCORE);
-        int totalScore = calculateTotalScore(memberId, courseId);
+        int totalScore = attendanceScore + weightedAssignmentScore + weightedExamScore + weightedAttitudeScore;
+
 
         return new AttendancePageDTO(
                 memberId,

--- a/src/main/java/com/wanted/projectmodule2lms/domain/attendance/model/service/InstructorAttendanceService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/attendance/model/service/InstructorAttendanceService.java
@@ -22,11 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -47,11 +44,31 @@ public class InstructorAttendanceService {
         List<Enrollment> enrollmentList = enrollmentRepository.findByCourseId(courseId);
         List<Section> sectionList = sectionRepository.findByCourseIdOrderBySectionOrderAsc(courseId);
 
+        Set<Integer> memberIds = enrollmentList.stream()
+                .map(Enrollment::getMemberId)
+                .collect(Collectors.toSet());
+
+        Map<Integer, Member> memberMap = memberRepository.findAllById(memberIds).stream()
+                .collect(Collectors.toMap(Member::getMemberId, member -> member));
+
+        List<Integer> enrollmentIds = enrollmentList.stream()
+                .map(Enrollment::getEnrollmentId)
+                .toList();
+
+        Map<Integer, Grade> gradeMap = gradeRepository.findByEnrollmentIdIn(enrollmentIds).stream()
+                .collect(Collectors.toMap(Grade::getEnrollmentId, grade -> grade));
+
+        List<Attendance> allAttendances = attendanceRepository
+                .findByEnrollmentIdInOrderByEnrollmentIdAscSectionIdAsc(enrollmentIds);
+
+        Map<Integer, List<Attendance>> attendanceMap = allAttendances.stream()
+                .collect(Collectors.groupingBy(Attendance::getEnrollmentId));
+
         for (Enrollment enrollment : enrollmentList) {
-            Member member = memberRepository.findById(enrollment.getMemberId()).orElse(null);
-            Grade grade = gradeRepository.findByEnrollmentId(enrollment.getEnrollmentId()).orElse(null);
-            List<Attendance> attendanceList = findLatestAttendancesByEnrollmentId(
-                    enrollment.getEnrollmentId()
+            Member member = memberMap.get(enrollment.getMemberId());
+            Grade grade = gradeMap.get(enrollment.getEnrollmentId());
+            List<Attendance> attendanceList = findLatestAttendances(
+                    attendanceMap.getOrDefault(enrollment.getEnrollmentId(), Collections.emptyList())
             );
 
             if (member == null) {
@@ -76,6 +93,21 @@ public class InstructorAttendanceService {
 
         return studentList;
     }
+
+    private List<Attendance> findLatestAttendances(List<Attendance> attendances) {
+        Map<Integer, Attendance> latestAttendanceBySection = new LinkedHashMap<>();
+
+        for (Attendance attendance : attendances) {
+            Attendance current = latestAttendanceBySection.get(attendance.getSectionId());
+
+            if (current == null || ATTENDANCE_ORDER.compare(attendance, current) > 0) {
+                latestAttendanceBySection.put(attendance.getSectionId(), attendance);
+            }
+        }
+
+        return new ArrayList<>(latestAttendanceBySection.values());
+    }
+
 
     @Transactional
     public void updateAttendanceStatusByInstructor(Integer instructorId,

--- a/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/service/CommentService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/service/CommentService.java
@@ -19,6 +19,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -35,10 +37,16 @@ public class CommentService {
     public List<CommentViewDTO> findCommentsByPostId(Integer postId) {
         List<Comment> commentList = commentRepository.findByPostIdAndIsDeletedFalseOrderByCommentIdAsc(postId);
 
+        Set<Integer> memberIds = commentList.stream()
+                .map(Comment::getMemberId)
+                .collect(Collectors.toSet());
+
+        Map<Integer, Member> memberMap = memberRepository.findAllById(memberIds).stream()
+                .collect(Collectors.toMap(Member::getMemberId, member -> member));
+
         return commentList.stream()
                 .map(comment -> {
-                    Member member = memberRepository.findById(comment.getMemberId())
-                            .orElse(null);
+                    Member member = memberMap.get(comment.getMemberId());
                     return toCommentViewDTO(comment, member);
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당하는 항목에 체크하세요 -->
- [ ] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [x] ♻️ REFACTOR
- [ ] 📝 DOCS


---

## 🔗 관련 이슈
Closes #146 

---

## 🛠️ 작업 내용
- 게시글 상세 댓글 조회에서 작성자 정보를 댓글마다 개별 조회하지 않도록 bulk 조회 방식으로 최적화했습니다.
- 학생 출석 페이지에서 총점 계산 시 동일한 출석/성적 데이터를 재조회하지 않도록 중복 계산 로직을 제거했습니다.
- 강사용 출석 관리 페이지에서 회원, 성적, 출석 데이터를 한 번에 조회한 뒤 `Map`으로 재사용하도록 변경했습니다.


---

## 🔄 변경 사항
- `CommentService`에서 댓글 작성자 조회를 `findAllById()` + `memberMap` 방식으로 바꿔 댓글 목록 조회 시 N+1 패턴을 줄였습니다.
- `AttendanceService`에서 `findAttendancePage()` 내부 총점 계산을 이미 구한 점수 값으로 직접 계산하도록 변경해 불필요한 재조회와 중복 계산을 제거했습니다.
- `InstructorAttendanceService`, `AttendanceRepository`, `GradeRepository`를 수정해 회원/성적/출석 데이터를 bulk 조회하고 `Map` 기반으로 조합하도록 최적화했습니다.

---

## ✅ 체크리스트
- [x] 팀 코딩 컨벤션을 준수했습니다.
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 불필요한 코드는 제거했습니다.
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우).