### PR TITLE
[UPDATE] 게시글 상세 페이지 댓글 렌더링 구조 및 단건 DTO 조립 최적화

### DIFF
--- a/src/main/java/com/wanted/projectmodule2lms/domain/board/controller/BoardController.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/board/controller/BoardController.java
@@ -4,7 +4,7 @@ import com.wanted.projectmodule2lms.domain.board.model.dto.BoardViewDTO;
 import com.wanted.projectmodule2lms.domain.board.model.entity.BoardType;
 import com.wanted.projectmodule2lms.domain.board.model.service.BoardService;
 import com.wanted.projectmodule2lms.domain.comment.model.dto.CommentDTO;
-import com.wanted.projectmodule2lms.domain.comment.model.dto.CommentViewDTO;
+import com.wanted.projectmodule2lms.domain.comment.model.dto.CommentThreadDTO;
 import com.wanted.projectmodule2lms.domain.comment.model.service.CommentService;
 import com.wanted.projectmodule2lms.domain.course.model.entity.Course;
 import com.wanted.projectmodule2lms.domain.member.model.entity.MemberRole;
@@ -115,9 +115,9 @@ public class BoardController {
     @GetMapping("/detail")
     public String boardDetailPage(@RequestParam Integer postId, Model model) {
         BoardViewDTO board = boardService.findBoardById(postId);
-        List<CommentViewDTO> commentList = commentService.findCommentsByPostId(postId);
+        List<CommentThreadDTO> commentThreads = commentService.findCommentThreadsByPostId(postId);
         model.addAttribute("board", board);
-        model.addAttribute("commentList", commentList);
+        model.addAttribute("commentThreads", commentThreads);
         model.addAttribute("listPath", getListPath(board.getPostType(), board.getCourseId()));
         return "board/detail";
     }

--- a/src/main/java/com/wanted/projectmodule2lms/domain/board/model/service/BoardService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/board/model/service/BoardService.java
@@ -64,7 +64,7 @@ public class    BoardService {
     }
 
     public BoardViewDTO findBoardById(Integer postId) {
-        return toBoardViewDTO(findActiveBoard(postId));
+        return toBoardDetailViewDTO(findActiveBoard(postId));
     }
 
     public List<Course> findAllCourses() {
@@ -388,6 +388,41 @@ public class    BoardService {
                 loadCourseTitleMap(Collections.singletonList(board)),
                 loadCourseInstructorMap(Collections.singletonList(board)),
                 loadSectionTitleMap(Collections.singletonList(board))
+        );
+    }
+
+    private BoardViewDTO toBoardDetailViewDTO(Board board) {
+        Member member = memberRepository.findById(board.getMemberId()).orElse(null);
+
+        Course course = null;
+        if (board.getCourseId() != null) {
+            course = courseRepository.findById(board.getCourseId()).orElse(null);
+        }
+
+        Section section = null;
+        if (board.getSectionId() != null) {
+            section = sectionRepository.findById(board.getSectionId()).orElse(null);
+        }
+
+        return new BoardViewDTO(
+                board.getPostId(),
+                board.getMemberId(),
+                member != null ? member.getName() : null,
+                board.getCourseId(),
+                course != null ? course.getTitle() : null,
+                course != null ? course.getInstructorId() : null,
+                board.getSectionId(),
+                section != null ? section.getTitle() : null,
+                board.getTitle(),
+                board.getContent(),
+                board.getPostType(),
+                board.getIsSecret(),
+                board.getAnswerStatus(),
+                board.getViewCount(),
+                board.getIsDeleted(),
+                board.getCreatedAt(),
+                board.getUpdatedAt(),
+                member != null && member.getProfile() != null ? member.getProfile().getProfileImage() : null
         );
     }
 

--- a/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/dto/CommentThreadDTO.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/dto/CommentThreadDTO.java
@@ -1,0 +1,13 @@
+package com.wanted.projectmodule2lms.domain.comment.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CommentThreadDTO {
+    private CommentViewDTO parent;
+    private List<CommentViewDTO> replies;
+}

--- a/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/service/CommentService.java
+++ b/src/main/java/com/wanted/projectmodule2lms/domain/comment/model/service/CommentService.java
@@ -5,6 +5,7 @@ import com.wanted.projectmodule2lms.domain.board.model.entity.BoardType;
 import com.wanted.projectmodule2lms.domain.board.model.service.BoardService;
 import com.wanted.projectmodule2lms.domain.comment.model.dao.CommentRepository;
 import com.wanted.projectmodule2lms.domain.comment.model.dto.CommentDTO;
+import com.wanted.projectmodule2lms.domain.comment.model.dto.CommentThreadDTO;
 import com.wanted.projectmodule2lms.domain.comment.model.dto.CommentViewDTO;
 import com.wanted.projectmodule2lms.domain.comment.model.entity.Comment;
 import com.wanted.projectmodule2lms.domain.course.model.dao.CourseRepository;
@@ -14,10 +15,10 @@ import com.wanted.projectmodule2lms.domain.member.model.dao.MemberRepository;
 import com.wanted.projectmodule2lms.domain.member.model.entity.Member;
 import com.wanted.projectmodule2lms.domain.member.model.entity.MemberRole;
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,7 +29,6 @@ import java.util.stream.Collectors;
 public class CommentService {
 
     private final CommentRepository commentRepository;
-    private final ModelMapper modelMapper;
     private final MemberRepository memberRepository;
     private final BoardService boardService;
     private final CourseRepository courseRepository;
@@ -181,4 +181,25 @@ public class CommentService {
                 .map(Enrollment::getCourseId)
                 .anyMatch(courseId::equals);
     }
+
+    public List<CommentThreadDTO> findCommentThreadsByPostId(Integer postId) {
+        List<CommentViewDTO> comments = findCommentsByPostId(postId);
+
+        List<CommentViewDTO> parents = comments.stream()
+                .filter(comment -> comment.getParentCommentId() == null)
+                .toList();
+
+        Map<Integer, List<CommentViewDTO>> replyMap = comments.stream()
+                .filter(comment -> comment.getParentCommentId() != null)
+                .collect(Collectors.groupingBy(CommentViewDTO::getParentCommentId));
+
+        return parents.stream()
+                .map(parent -> new CommentThreadDTO(
+                        parent,
+                        replyMap.getOrDefault(parent.getCommentId(), Collections.emptyList())
+                ))
+                .toList();
+    }
+
+
 }

--- a/src/main/resources/templates/board/detail.html
+++ b/src/main/resources/templates/board/detail.html
@@ -93,7 +93,8 @@
             </tr>
             </thead>
             <tbody>
-            <th:block th:each="comment : ${commentList}" th:if="${comment.parentCommentId == null}">
+            <th:block th:each="thread : ${commentThreads}">
+                <th:block th:with="comment=${thread.parent}">
                 <tr>
                     <td>
                         <div style="display: inline-flex; align-items: center; gap: 8px;">
@@ -174,7 +175,7 @@
                     </td>
                 </tr>
 
-                <th:block th:each="reply : ${commentList}" th:if="${reply.parentCommentId == comment.commentId}">
+                <th:block th:each="reply : ${thread.replies}">
                     <tr>
                         <td>
                             <div style="display: inline-flex; align-items: center; gap: 8px; padding-left: 10px;">
@@ -276,8 +277,9 @@
                         </form>
                     </td>
                 </tr>
+                </th:block>
             </th:block>
-            <tr th:if="${commentList == null or #lists.isEmpty(commentList)}">
+            <tr th:if="${commentThreads == null or #lists.isEmpty(commentThreads)}">
                 <td colspan="4">등록된 댓글이 없습니다.</td>
             </tr>
             </tbody>


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당하는 항목에 체크하세요 -->
- [ ] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [x] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 🔗 관련 이슈
Closes #150 

---

## 🛠️ 작업 내용
- 게시글 상세 페이지에서 댓글/대댓글 렌더링 구조를 `CommentThreadDTO` 기반으로 바꿔 템플릿 중첩 순회를 줄였습니다.
- `BoardController`가 상세 페이지에 `commentList` 대신 `commentThreads`를 전달하도록 수정했습니다.
- `BoardService.findBoardById()`가 단건 상세 전용 DTO 조립 메서드를 사용하도록 변경해 상세 조회 흐름을 단순화했습니다.

---

## 🔄 변경 사항
- `CommentService.findCommentThreadsByPostId()`를 활용해 부모 댓글과 대댓글을 서비스 계층에서 미리 묶은 뒤 화면에 전달하도록 변경했습니다.
- `detail.html`에서 부모 댓글마다 전체 댓글 리스트를 다시 순회하던 구조를 제거하고, `thread.parent`와 `thread.replies`만 렌더링하도록 수정했습니다.
- `BoardService`에 `toBoardDetailViewDTO()`를 추가하고, 게시글 상세 조회 시 목록용 보조 map 조립 대신 단건 전용 조립 방식을 사용하도록 정리했습니다.

---

## ✅ 체크리스트
- [x] 팀 코딩 컨벤션을 준수했습니다.
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 불필요한 코드는 제거했습니다.
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우).