### PR TITLE
[UPDATE] 주요 화면 공통 상단바 적용 및 헤더 UI 통일

### DIFF
--- a/src/main/resources/templates/admin/certificate/list.html
+++ b/src/main/resources/templates/admin/certificate/list.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-[#f6f7fb] text-slate-900">
+<div th:replace="~{common/topbar :: topbar}"></div>
 <div class="min-h-screen">
     <div class="mx-auto max-w-7xl px-6 py-10">
         <div class="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">

--- a/src/main/resources/templates/board/admin-notice-list.html
+++ b/src/main/resources/templates/board/admin-notice-list.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="/css/board/crud.css">
 </head>
 <body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId}">
+<div th:replace="~{common/topbar :: topbar}"></div>
 <div class="page-wrapper">
     <div class="top-utility">
         <div class="role-panel">

--- a/src/main/resources/templates/board/course-notice-list.html
+++ b/src/main/resources/templates/board/course-notice-list.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="/css/board/crud.css">
 </head>
 <body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId}">
+<div th:replace="~{common/topbar :: topbar}"></div>
 <div class="page-wrapper">
     <div class="top-utility">
         <div class="role-panel">

--- a/src/main/resources/templates/board/detail.html
+++ b/src/main/resources/templates/board/detail.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="/css/board/crud.css">
 </head>
 <body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId},data-post-id=${board.postId}">
+<div th:replace="~{common/topbar :: topbar}"></div>
 <div class="page-wrapper">
     <div class="top-utility">
         <div class="role-panel">

--- a/src/main/resources/templates/board/free-list.html
+++ b/src/main/resources/templates/board/free-list.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="/css/board/crud.css">
 </head>
 <body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId}">
+<div th:replace="~{common/topbar :: topbar}"></div>
 <div class="page-wrapper">
     <div class="top-utility">
         <div class="role-panel">

--- a/src/main/resources/templates/board/list.html
+++ b/src/main/resources/templates/board/list.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="/css/board/crud.css">
 </head>
 <body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId}">
+<div th:replace="~{common/topbar :: topbar}"></div>
 <div class="page-wrapper">
     <div class="top-utility">
         <div class="page-main box" style="margin-bottom: 0;">

--- a/src/main/resources/templates/board/section-qna-list.html
+++ b/src/main/resources/templates/board/section-qna-list.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="/css/board/crud.css">
 </head>
 <body th:attr="data-current-role=${currentRole},data-current-member-id=${currentMemberId}">
+<div th:replace="~{common/topbar :: topbar}"></div>
 <div class="page-wrapper">
     <div class="top-utility">
         <div class="role-panel">

--- a/src/main/resources/templates/common/topbar.html
+++ b/src/main/resources/templates/common/topbar.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<body>
+<th:block th:fragment="topbar">
+    <style>
+        .shared-topbar {
+            position: sticky;
+            top: 0;
+            z-index: 1000;
+            border-bottom: 1px solid rgba(219, 227, 241, 0.95);
+            background: rgba(255, 255, 255, 0.96);
+            backdrop-filter: blur(14px);
+            box-shadow: 0 10px 24px rgba(15, 23, 42, 0.06);
+        }
+
+        .shared-topbar__inner {
+            max-width: 1340px;
+            margin: 0 auto;
+            padding: 18px 24px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 20px;
+        }
+
+        .shared-topbar__brand {
+            color: #2b3f8f;
+            font-size: 2rem;
+            font-weight: 800;
+            line-height: 1;
+            letter-spacing: -0.04em;
+            text-decoration: none;
+        }
+
+        .shared-topbar__actions {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+        }
+
+        .shared-topbar__profile {
+            width: 44px;
+            height: 44px;
+            border-radius: 999px;
+            overflow: hidden;
+            border: 1px solid #e5e7eb;
+            background: #f8fafc;
+            box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+            flex-shrink: 0;
+        }
+
+        .shared-topbar__profile img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .shared-topbar__welcome {
+            color: #475569;
+            font-size: 0.98rem;
+            font-weight: 600;
+            white-space: nowrap;
+        }
+
+        .shared-topbar__welcome strong {
+            color: #2b3f8f;
+            font-weight: 800;
+        }
+
+        .shared-topbar__logout {
+            border: 1px solid #e5e7eb;
+            border-radius: 999px;
+            background: #ffffff;
+            color: #334155;
+            padding: 10px 18px;
+            font-size: 0.95rem;
+            font-weight: 700;
+            cursor: pointer;
+            transition: border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+        }
+
+        .shared-topbar__logout:hover {
+            border-color: #2b3f8f;
+            color: #2b3f8f;
+            transform: translateY(-1px);
+        }
+
+        @media (max-width: 768px) {
+            .shared-topbar__inner {
+                padding: 14px 16px;
+            }
+
+            .shared-topbar__brand {
+                font-size: 1.7rem;
+            }
+
+            .shared-topbar__welcome {
+                display: none;
+            }
+        }
+    </style>
+
+    <header class="shared-topbar">
+        <div class="shared-topbar__inner">
+            <a th:href="@{/}" class="shared-topbar__brand">64Lab</a>
+
+            <div class="shared-topbar__actions">
+                <div class="shared-topbar__profile">
+                    <img th:src="${member != null and member.profile != null and member.profile.profileImage != null and member.profile.profileImage != ''}
+                                     ? '/uploads/' + ${member.profile.profileImage}
+                                     : '/img/default-profile.png'"
+                         alt="profile"
+                         onerror="this.src='/img/default-profile.png'">
+                </div>
+
+                <span class="shared-topbar__welcome">
+                    <strong th:text="${member != null and member.name != null ? member.name : #authentication.name}">사용자</strong>님, 환영합니다.
+                </span>
+
+                <form th:action="@{/auth/logout}" method="post">
+                    <button type="submit" class="shared-topbar__logout">로그아웃</button>
+                </form>
+            </div>
+        </div>
+    </header>
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/student/attendance/attendancepage.html
+++ b/src/main/resources/templates/student/attendance/attendancepage.html
@@ -79,17 +79,10 @@
     <link rel="stylesheet" th:href="@{/css/attendance/attendance.css}" href="/css/attendance/attendance.css"/>
 </head>
 <body class="bg-surface text-on-surface min-h-screen">
-<header class="fixed top-0 w-full flex justify-between items-center px-8 py-4 h-16 bg-[#f2f4f6]/80 backdrop-blur-xl z-50 border-b border-outline-variant/10">
-    <div class="flex items-center gap-8">
-        <span class="text-xl font-bold tracking-tight text-[#191c1e]">64Lab</span>
-        <nav class="hidden md:flex space-x-6">
-            <a class="text-[#0056D2] font-bold border-b-2 border-[#0056D2] pb-1 px-2" href="#">강의실</a>
-        </nav>
-    </div>
-</header>
+<div th:replace="~{common/topbar :: topbar}"></div>
 
-<aside class="fixed left-0 top-0 h-screen w-64 bg-[#f2f4f6] flex flex-col p-6 space-y-8 hidden lg:flex">
-    <div class="mt-16">
+<aside class="fixed left-0 top-[81px] h-[calc(100vh-81px)] w-64 bg-[#f2f4f6] flex flex-col p-6 space-y-8 hidden lg:flex">
+    <div>
         <div class="flex items-center gap-3 mb-2">
             <div class="w-10 h-10 rounded-lg bg-primary flex items-center justify-center text-on-primary">
                 <span class="material-symbols-outlined">school</span>
@@ -105,7 +98,7 @@
     </nav>
 </aside>
 
-<main class="lg:ml-64 pt-16 min-h-screen">
+<main class="lg:ml-64 min-h-screen">
     <div class="max-w-[1440px] mx-auto p-8 space-y-8">
         <section class="bg-surface-container-lowest rounded-xl p-8 relative overflow-hidden border border-outline-variant/10">
             <div class="relative z-10">

--- a/src/main/resources/templates/student/course/my-classroom.html
+++ b/src/main/resources/templates/student/course/my-classroom.html
@@ -7,6 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-[#f6f7fb] text-slate-900">
+<div th:replace="~{common/topbar :: topbar}"></div>
 <div class="min-h-screen">
     <div class="mx-auto max-w-7xl px-6 py-10">
         <div class="mb-10 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">


### PR DESCRIPTION
## 📌 PR 유형
<!-- 해당하는 항목에 체크하세요 -->
- [ ] ✨ FEATURE
- [x] 🔧 UPDATE
- [ ] 🐛 BUGFIX
- [ ] ♻️ REFACTOR
- [ ] 📝 DOCS

---

## 🔗 관련 이슈
Closes #166 

---

## 🛠️ 작업 내용
- 메인 페이지 스타일을 기준으로 공통 상단바 fragment를 추가했습니다.
- 게시판 메인/목록/상세, 학생 강의실, 학생 출석, 관리자 증명서 화면에 공통 상단바를 적용했습니다.
- 출석 페이지는 기존 고정 헤더와 충돌하지 않도록 레이아웃 간격과 사이드바 위치를 함께 조정했습니다.

---

## 🔄 변경 사항
- `common/topbar.html`을 추가해 로고, 프로필 이미지, 환영 문구, 로그아웃 버튼을 공통화했습니다.
- `board/list`, `board/admin-notice-list`, `board/course-notice-list`, `board/section-qna-list`, `board/free-list`, `board/detail` 화면 상단 UI를 통일했습니다.
- `student/course/my-classroom`, `student/attendance/attendancepage`, `admin/certificate/list` 화면에도 동일한 상단바를 적용해 주요 화면 헤더 경험을 맞췄습니다.

---

## ✅ 체크리스트
- [x] 팀 코딩 컨벤션을 준수했습니다.
- [x] 정상적으로 빌드 및 실행됩니다.
- [x] 불필요한 코드는 제거했습니다.
- [ ] 관련 문서를 업데이트했습니다 (필요한 경우).
